### PR TITLE
Railways improvements

### DIFF
--- a/src/hoi4_world/map/possible_path.h
+++ b/src/hoi4_world/map/possible_path.h
@@ -14,7 +14,6 @@ namespace hoi4
 class PossiblePath
 {
   public:
-   PossiblePath() = default;
    explicit PossiblePath(int initial_province) { provinces_.push_back(initial_province); }
 
    void AddProvince(int province, double additional_cost)
@@ -25,22 +24,8 @@ class PossiblePath
    void ReplaceProvinces(std::vector<int> new_provinces) { provinces_ = std::move(new_provinces); }
    void SetLevel(int level) { level_ = level; }
 
-   [[nodiscard]] std::optional<int> GetFirstProvince() const
-   {
-      if (provinces_.empty())
-      {
-         return std::nullopt;
-      }
-      return provinces_.front();
-   }
-   [[nodiscard]] std::optional<int> GetLastProvince() const
-   {
-      if (provinces_.empty())
-      {
-         return std::nullopt;
-      }
-      return provinces_.back();
-   }
+   [[nodiscard]] int GetFirstProvince() const { return provinces_.front(); }
+   [[nodiscard]] int GetLastProvince() const { return provinces_.back(); }
    [[nodiscard]] const std::vector<int>& GetProvinces() const { return provinces_; }
    [[nodiscard]] int GetLevel() const { return level_; }
    [[nodiscard]] double GetCost() const { return cost_; }

--- a/src/hoi4_world/map/possible_path_tests.cpp
+++ b/src/hoi4_world/map/possible_path_tests.cpp
@@ -10,35 +10,27 @@ namespace hoi4
 
 TEST(Hoi4worldMapPossiblePathTests, DefaultsAreSet)
 {
-   const PossiblePath possible_path;
+   const PossiblePath possible_path(1);
 
-   EXPECT_THAT(possible_path.GetProvinces(), testing::ElementsAre());
+   EXPECT_THAT(possible_path.GetProvinces(), testing::ElementsAre(1));
    EXPECT_EQ(possible_path.GetLevel(), 0);
    EXPECT_EQ(possible_path.GetCost(), 0);
 }
 
 
-TEST(Hoi4worldMapPossiblePathTests, InitialProvinceIsSetOnConstruction)
-{
-   const PossiblePath possible_path(1);
-
-   EXPECT_THAT(possible_path.GetProvinces(), testing::ElementsAre(1));
-}
-
-
 TEST(Hoi4worldMapPossiblePathTests, ProvincesCanBeAdded)
 {
-   PossiblePath possible_path;
+   PossiblePath possible_path(0);
    possible_path.AddProvince(1, 0);
    possible_path.AddProvince(2, 0);
 
-   EXPECT_THAT(possible_path.GetProvinces(), testing::ElementsAre(1, 2));
+   EXPECT_THAT(possible_path.GetProvinces(), testing::ElementsAre(0, 1, 2));
 }
 
 
 TEST(Hoi4worldMapPossiblePathTests, AddedProvincesIncreaseCost)
 {
-   PossiblePath possible_path;
+   PossiblePath possible_path(0);
    possible_path.AddProvince(1, 2);
    possible_path.AddProvince(2, 3);
 
@@ -49,7 +41,6 @@ TEST(Hoi4worldMapPossiblePathTests, AddedProvincesIncreaseCost)
 TEST(Hoi4worldMapPossiblePathTests, ProvinceCanBeReplaced)
 {
    PossiblePath possible_path(1);
-   possible_path.AddProvince(2, 0);
    possible_path.ReplaceProvinces({3, 4});
 
    EXPECT_THAT(possible_path.GetProvinces(), testing::ElementsAre(3, 4));
@@ -58,55 +49,37 @@ TEST(Hoi4worldMapPossiblePathTests, ProvinceCanBeReplaced)
 
 TEST(Hoi4worldMapPossiblePathTests, LevelCanBeSet)
 {
-   PossiblePath possible_path;
+   PossiblePath possible_path(0);
    possible_path.SetLevel(42);
 
    EXPECT_EQ(possible_path.GetLevel(), 42);
 }
 
 
-TEST(Hoi4worldMapPossiblePathTests, FirstProvinceIsNulloptForEmptyPath)
-{
-   const PossiblePath possible_path;
-
-   EXPECT_EQ(possible_path.GetFirstProvince(), std::nullopt);
-}
-
-
 TEST(Hoi4worldMapPossiblePathTests, FirstProvinceCanBeRetrieved)
 {
    PossiblePath possible_path(1);
-   possible_path.AddProvince(2, 0);
    possible_path.ReplaceProvinces({3, 4});
 
-   EXPECT_EQ(possible_path.GetFirstProvince(), std::make_optional(3));
-}
-
-
-TEST(Hoi4worldMapPossiblePathTests, LastProvinceIsNulloptForEmptyPath)
-{
-   const PossiblePath possible_path;
-
-   EXPECT_EQ(possible_path.GetLastProvince(), std::nullopt);
+   EXPECT_EQ(possible_path.GetFirstProvince(), 3);
 }
 
 
 TEST(Hoi4worldMapPossiblePathTests, LastProvinceCanBeRetrieved)
 {
    PossiblePath possible_path(1);
-   possible_path.AddProvince(2, 0);
    possible_path.ReplaceProvinces({3, 4});
 
-   EXPECT_EQ(possible_path.GetLastProvince(), std::make_optional(4));
+   EXPECT_EQ(possible_path.GetLastProvince(), 4);
 }
 
 
 TEST(Hoi4worldMapPossiblePathTests, LessThanIsBasedOnCostAndReversed)
 {
-   PossiblePath possible_path_one;
+   PossiblePath possible_path_one(0);
    possible_path_one.AddProvince(1, 2);
 
-   PossiblePath possible_path_two;
+   PossiblePath possible_path_two(0);
    possible_path_two.AddProvince(1, 3);
 
    EXPECT_LT(possible_path_two, possible_path_one);

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -643,11 +643,6 @@ std::map<int, int> CountInstancesOfEndpoints(const std::vector<hoi4::PossiblePat
          itr->second++;
       }
 
-      if (path.GetProvinces().size() == 1)
-      {
-         continue;
-      }
-
       if (auto [itr, success] = num_uses_of_endpoints.emplace(path.GetLastProvince(), 1); !success)
       {
          itr->second++;

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -37,7 +37,7 @@ std::vector<std::pair<std::string, std::string>> DetermineVic3Endpoints(
          continue;
       }
 
-      for (const auto& significant_province: significant_provinces | std::views::keys)
+      for (const auto& significant_province: other_significant_provinces)
       {
          if (significant_province == city_province)
          {

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -442,6 +442,12 @@ std::vector<hoi4::PossiblePath> ConnectStatesWithRailways(
       }
       for (const int neighbor_id: neighbors_itr->second)
       {
+         // skip connections already done from the other direction
+         if (neighbor_id < id)
+         {
+            continue;
+         }
+
          const std::set<int>& neighbor_significant_provinces =
              GetSignificantProvincesInState(neighbor_id, significant_provinces_in_states);
          const std::vector<std::pair<int, int>> interstate_connections =
@@ -461,29 +467,7 @@ std::vector<hoi4::PossiblePath> ConnectStatesWithRailways(
       }
    }
 
-   std::vector<hoi4::PossiblePath> deduplicated_interstate_paths;
-   std::set<std::pair<int, int>> used_endpoints;
-   for (const auto& path: interstate_paths)
-   {
-      std::optional<int> first_province = path.GetFirstProvince();
-      std::optional<int> last_province = path.GetLastProvince();
-      if (!first_province || !last_province)
-      {
-         continue;
-      }
-      if (used_endpoints.contains({*first_province, *last_province}))
-      {
-         continue;
-      }
-      if (used_endpoints.contains({*last_province, *first_province}))
-      {
-         continue;
-      }
-      used_endpoints.emplace(*first_province, *last_province);
-      deduplicated_interstate_paths.push_back(path);
-   }
-
-   return deduplicated_interstate_paths;
+   return interstate_paths;
 }
 
 

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -7,7 +7,7 @@
 #include "src/hoi4_world/map/possible_path.h"
 
 
-
+#pragma optimize("", off)
 namespace
 {
 
@@ -80,11 +80,6 @@ std::vector<std::pair<int, int>> ConvertVic3EndpointsToHoi4Endpoints(
       }
 
       std::pair<int, int> pair{hoi4_province_start_point, hoi4_province_end_point};
-      if (handled_hoi4_endpoints.contains(pair))
-      {
-         continue;
-      }
-
       hoi4_endpoints.emplace_back(pair);
       handled_hoi4_endpoints.emplace(pair);
    }
@@ -762,3 +757,4 @@ hoi4::Railways hoi4::ConvertRailways(const std::map<std::string, vic3::StateRegi
 
    return {railways, endpoints};
 }
+#pragma optimize("", on)

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -546,11 +546,6 @@ std::vector<hoi4::PossiblePath> SplitPaths(const std::vector<hoi4::PossiblePath>
             handled_paths.insert(endpoints);
          }
          split_path.ReplaceProvinces({province});
-
-         Log(LogLevel::Info) << fmt::format("A path from {} to {} passed over {} and was trimmed.",
-             *path.GetFirstProvince(),
-             *path.GetLastProvince(),
-             province);
       }
 
       std::pair<int, int> endpoints = {*split_path.GetFirstProvince(), *split_path.GetLastProvince()};
@@ -608,6 +603,7 @@ hoi4::Railways hoi4::ConvertRailways(const std::map<std::string, vic3::StateRegi
     const maps::ProvinceDefinitions& hoi4_province_definitions,
     const States& hoi4_states)
 {
+   Log(LogLevel::Info) << "Creating railways";
    const std::vector<std::pair<std::string, std::string>> vic3_endpoints = DetermineVic3Endpoints(vic3_state_regions);
    const std::vector<std::pair<int, int>> intrastate_hoi4_endpoints =
        ConvertVic3EndpointsToHoi4Endpoints(vic3_endpoints, province_mapper);

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -20,7 +20,7 @@ std::vector<std::pair<std::string, std::string>> DetermineVic3Endpoints(
    {
       const std::map<std::string, std::string>& significant_provinces = vic3_state_region.GetSignificantProvinces();
       std::string city_province;
-      std::vector<std::string> other_significant_provinces;
+      std::set<std::string> other_significant_provinces;
       for (const auto& [province, type]: significant_provinces)
       {
          if (type == "city")
@@ -29,7 +29,7 @@ std::vector<std::pair<std::string, std::string>> DetermineVic3Endpoints(
          }
          else
          {
-            other_significant_provinces.push_back(province);
+            other_significant_provinces.insert(province);
          }
       }
       if (city_province.empty())
@@ -58,6 +58,8 @@ std::vector<std::pair<int, int>> ConvertVic3EndpointsToHoi4Endpoints(
 {
    std::vector<std::pair<int, int>> hoi4_endpoints;
 
+   // an extra copy for deduping, even though we want to preserve the order in the final output
+   std::set<std::pair<int, int>> handled_hoi4_endpoints;
    for (const auto& [vic3_start_point, vic3_end_point]: vic3_endpoints)
    {
       std::vector<int> hoi4_province_start_points = province_mapper.GetVic3ToHoi4ProvinceMapping(vic3_start_point);
@@ -77,7 +79,14 @@ std::vector<std::pair<int, int>> ConvertVic3EndpointsToHoi4Endpoints(
          continue;
       }
 
-      hoi4_endpoints.emplace_back(hoi4_province_start_point, hoi4_province_end_point);
+      std::pair<int, int> pair{hoi4_province_start_point, hoi4_province_end_point};
+      if (handled_hoi4_endpoints.contains(pair))
+      {
+         continue;
+      }
+
+      hoi4_endpoints.emplace_back(pair);
+      handled_hoi4_endpoints.emplace(pair);
    }
 
    return hoi4_endpoints;

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -93,16 +93,16 @@ std::vector<std::pair<int, int>> ConvertVic3EndpointsToHoi4Endpoints(
 }
 
 
-constexpr int urban_cost = 1;
-constexpr int plains_cost = 2;
-constexpr int forest_cost = 3;
-constexpr int hills_cost = 4;
-constexpr int desert_cost = 5;
-constexpr int marsh_cost = 6;
-constexpr int jungle_cost = 7;
-constexpr int mountain_cost = 8;
-constexpr int unhandled_cost = 100;
-int GetCostForTerrainType(std::string_view terrain_type)
+constexpr float urban_cost = 1.F;
+constexpr float plains_cost = 2.F;
+constexpr float forest_cost = 3.F;
+constexpr float hills_cost = 4.F;
+constexpr float desert_cost = 5.F;
+constexpr float marsh_cost = 6.F;
+constexpr float jungle_cost = 7.F;
+constexpr float mountain_cost = 8.F;
+constexpr float unhandled_cost = 100.F;
+float GetCostForTerrainType(std::string_view terrain_type)
 {
    if (terrain_type == "urban")
    {
@@ -169,13 +169,22 @@ double DeterminePathCost(const maps::ProvinceDefinitions& hoi4_province_definiti
     const std::string& last_province,
     const maps::MapData& hoi4_map_data)
 {
-   const std::optional<std::string> possible_terrain_type = hoi4_province_definitions.GetTerrainType(neighbor_number);
-   if (!possible_terrain_type)
+   const std::optional<std::string> possible_current_terrain_type =
+       hoi4_province_definitions.GetTerrainType(last_province);
+   if (!possible_current_terrain_type)
    {
       return std::numeric_limits<double>::max();
    }
 
-   return GetCostForTerrainType(*possible_terrain_type) *
+   const std::optional<std::string> possible_neighbor_terrain_type =
+       hoi4_province_definitions.GetTerrainType(neighbor_number);
+   if (!possible_neighbor_terrain_type)
+   {
+      return std::numeric_limits<double>::max();
+   }
+
+   return (GetCostForTerrainType(*possible_current_terrain_type) +
+              GetCostForTerrainType(*possible_neighbor_terrain_type) / 2.0F) *
           GetDistanceBetweenProvinces(neighbor_number, last_province, hoi4_map_data);
 }
 

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -186,13 +186,8 @@ void FindNextPaths(const hoi4::PossiblePath& possible_railway_path,
     std::set<int>& reached_provinces,
     std::priority_queue<hoi4::PossiblePath>& possible_railway_paths)
 {
-   const std::optional<int> last_province = possible_railway_path.GetLastProvince();
-   if (!last_province)
-   {
-      return;
-   }
-
-   for (const auto& neighbor_number_string: hoi4_map_data.GetNeighbors(std::to_string(*last_province)))
+   const int last_province = possible_railway_path.GetLastProvince();
+   for (const auto& neighbor_number_string: hoi4_map_data.GetNeighbors(std::to_string(last_province)))
    {
       int neighbor_number = 0;
       try
@@ -218,7 +213,7 @@ void FindNextPaths(const hoi4::PossiblePath& possible_railway_path,
       new_possible_railway_path.AddProvince(neighbor_number,
           DeterminePathCost(hoi4_province_definitions,
               neighbor_number_string,
-              std::to_string(*last_province),
+              std::to_string(last_province),
               hoi4_map_data));
       possible_railway_paths.push(new_possible_railway_path);
    }
@@ -240,8 +235,7 @@ std::optional<hoi4::PossiblePath> FindPath(int start_province,
    {
       hoi4::PossiblePath possible_railway_path = possible_railway_paths.top();
 
-      const auto last_province = possible_railway_path.GetLastProvince();
-      if (!last_province || *last_province == end_province)
+      if (possible_railway_path.GetLastProvince() == end_province)
       {
          break;
       }
@@ -485,14 +479,8 @@ std::set<int> ListEndpoints(const std::vector<hoi4::PossiblePath>& all_paths)
    std::set<int> endpoints;
    for (const auto& path: all_paths)
    {
-      const std::optional<int> possible_first_province = path.GetFirstProvince();
-      if (!possible_first_province)
-      {
-         continue;
-      }
-
-      endpoints.insert(*path.GetFirstProvince());
-      endpoints.insert(*path.GetLastProvince());
+      endpoints.insert(path.GetFirstProvince());
+      endpoints.insert(path.GetLastProvince());
    }
 
    return endpoints;
@@ -508,12 +496,7 @@ std::vector<hoi4::PossiblePath> SplitPaths(const std::vector<hoi4::PossiblePath>
 
    for (const hoi4::PossiblePath& path: all_paths)
    {
-      if (!path.GetFirstProvince())
-      {
-         continue;
-      }
-
-      hoi4::PossiblePath split_path(*path.GetFirstProvince());
+      hoi4::PossiblePath split_path(path.GetFirstProvince());
       split_path.SetLevel(path.GetLevel());
       for (int province: path.GetProvinces())
       {
@@ -534,7 +517,7 @@ std::vector<hoi4::PossiblePath> SplitPaths(const std::vector<hoi4::PossiblePath>
             continue;
          }
 
-         std::pair<int, int> current_endpoints = {*split_path.GetFirstProvince(), *split_path.GetLastProvince()};
+         std::pair<int, int> current_endpoints = {split_path.GetFirstProvince(), split_path.GetLastProvince()};
          if (!handled_paths.contains(current_endpoints))
          {
             split_paths.push_back(split_path);
@@ -543,7 +526,7 @@ std::vector<hoi4::PossiblePath> SplitPaths(const std::vector<hoi4::PossiblePath>
          split_path.ReplaceProvinces({province});
       }
 
-      std::pair<int, int> current_endpoints = {*split_path.GetFirstProvince(), *split_path.GetLastProvince()};
+      std::pair<int, int> current_endpoints = {split_path.GetFirstProvince(), split_path.GetLastProvince()};
       if (!handled_paths.contains(current_endpoints))
       {
          split_paths.push_back(split_path);
@@ -575,14 +558,8 @@ std::set<int> GetEndpointsFromPaths(const std::vector<hoi4::PossiblePath>& paths
 
    for (const hoi4::PossiblePath& possible_path: paths)
    {
-      if (std::optional<int> possible_endpoint = possible_path.GetFirstProvince(); possible_endpoint)
-      {
-         endpoints.insert(*possible_endpoint);
-      }
-      if (std::optional<int> possible_endpoint = possible_path.GetLastProvince(); possible_endpoint)
-      {
-         endpoints.insert(*possible_endpoint);
-      }
+      endpoints.insert(possible_path.GetFirstProvince());
+      endpoints.insert(possible_path.GetLastProvince());
    }
 
    return endpoints;

--- a/src/hoi4_world/map/railways_converter.cpp
+++ b/src/hoi4_world/map/railways_converter.cpp
@@ -7,7 +7,7 @@
 #include "src/hoi4_world/map/possible_path.h"
 
 
-#pragma optimize("", off)
+
 namespace
 {
 
@@ -752,4 +752,3 @@ hoi4::Railways hoi4::ConvertRailways(const std::map<std::string, vic3::StateRegi
 
    return {railways, endpoints};
 }
-#pragma optimize("", on)

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -231,6 +231,50 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoIntrastateRailwaysToSameHoi4Province)
 }
 
 
+TEST(Hoi4worldMapRailwaysConverterTests, OneInstanceOfEachIntrastateRailway)
+{
+    const std::map<std::string, vic3::StateRegion> vic3_state_regions{
+        {"STATE_ONE",
+            vic3::StateRegion{{
+                {"0x000001", "city"},
+                { "0x000002", "dock" },
+                { "0x000003", "mine" },
+                },
+            {}}},
+    };
+
+    const mappers::ProvinceMapper province_mapper{{
+        {"0x000001", { 1 }},
+        { "0x000002", {2} },
+        { "0x000003", {2} },
+        },
+        {}};
+
+    const maps::MapData hoi4_map_data{{
+            .province_neighbors =
+            {
+                {"1", {"2"}},
+            },
+        }};
+
+    const maps::ProvinceDefinitions hoi4_province_definitions{{
+            .land_provinces = { "1", "2" },
+        }};
+
+    const Railways railways = ConvertRailways(vic3_state_regions,
+        province_mapper,
+        hoi4_map_data,
+        hoi4_province_definitions,
+        { .states =
+                {
+                    State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 2}),
+                },
+            .province_to_state_id_map = {{1, 1}, {2,1}} });
+
+    EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, { 1, 2 })));
+}
+
+
 TEST(Hoi4worldMapRailwaysConverterTests, NoRailwayForUnmappedProvinces)
 {
    const std::map<std::string, vic3::StateRegion> vic3_state_regions{

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -233,45 +233,45 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoIntrastateRailwaysToSameHoi4Province)
 
 TEST(Hoi4worldMapRailwaysConverterTests, OneInstanceOfEachIntrastateRailway)
 {
-    const std::map<std::string, vic3::StateRegion> vic3_state_regions{
-        {"STATE_ONE",
-            vic3::StateRegion{{
-                {"0x000001", "city"},
-                { "0x000002", "dock" },
-                { "0x000003", "mine" },
-                },
-            {}}},
-    };
+   const std::map<std::string, vic3::StateRegion> vic3_state_regions{
+       {"STATE_ONE",
+           vic3::StateRegion{{
+                                 {"0x000001", "city"},
+                                 {"0x000002", "dock"},
+                                 {"0x000003", "mine"},
+                             },
+               {}}},
+   };
 
-    const mappers::ProvinceMapper province_mapper{{
-        {"0x000001", { 1 }},
-        { "0x000002", {2} },
-        { "0x000003", {2} },
-        },
-        {}};
+   const mappers::ProvinceMapper province_mapper{{
+                                                     {"0x000001", {1}},
+                                                     {"0x000002", {2}},
+                                                     {"0x000003", {2}},
+                                                 },
+       {}};
 
-    const maps::MapData hoi4_map_data{{
-            .province_neighbors =
-            {
-                {"1", {"2"}},
-            },
-        }};
+   const maps::MapData hoi4_map_data{{
+       .province_neighbors =
+           {
+               {"1", {"2"}},
+           },
+   }};
 
-    const maps::ProvinceDefinitions hoi4_province_definitions{{
-            .land_provinces = { "1", "2" },
-        }};
+   const maps::ProvinceDefinitions hoi4_province_definitions{{
+       .land_provinces = {"1", "2"},
+   }};
 
-    const Railways railways = ConvertRailways(vic3_state_regions,
-        province_mapper,
-        hoi4_map_data,
-        hoi4_province_definitions,
-        { .states =
-                {
-                    State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 2}),
-                },
-            .province_to_state_id_map = {{1, 1}, {2,1}} });
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 2}),
+               },
+           .province_to_state_id_map = {{1, 1}, {2, 1}}});
 
-    EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, { 1, 2 })));
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2})));
 }
 
 
@@ -1167,6 +1167,18 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastr
                                  {"0x000010", "dock"},
                              },
                {}}},
+       {"STATE_6_BAD_START_POINT",
+           vic3::StateRegion{{
+                                 {"0x000011", "city"},
+                                 {"0x000012", "dock"},
+                             },
+               {}}},
+       {"STATE_7_BAD_END_POINT",
+           vic3::StateRegion{{
+                                 {"0x000013", "city"},
+                                 {"0x000014", "dock"},
+                             },
+               {}}},
    };
 
    const mappers::ProvinceMapper province_mapper{{
@@ -1180,6 +1192,10 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastr
                                                      {"0x000008", {8}},
                                                      {"0x000009", {9}},
                                                      {"0x000010", {10}},
+                                                     {"0x000011", {11}},
+                                                     {"0x000012", {12}},
+                                                     {"0x000013", {13}},
+                                                     {"0x000014", {14}},
                                                  },
        {}};
 
@@ -1191,11 +1207,13 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastr
                {"5", {"6"}},
                {"7", {"8"}},
                {"9", {"10"}},
+               {"11", {"12"}},
+               {"13", {"14"}},
            },
    }};
 
    const maps::ProvinceDefinitions hoi4_province_definitions{{
-       .land_provinces = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
+       .land_provinces = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"},
    }};
 
    const Railways railways = ConvertRailways(vic3_state_regions,
@@ -1223,9 +1241,17 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastr
                            .vic3_infrastructure = 166.F}),
                    State(5,
                        StateOptions{.victory_points = {{9, 1}}, .naval_base_location = 10, .vic3_infrastructure = 0.F}),
+                   State(6,
+                       StateOptions{.victory_points = {{11, 1}},
+                           .naval_base_location = 12,
+                           .vic3_infrastructure = 0.F}),
+                   State(7,
+                       StateOptions{.victory_points = {{13, 1}},
+                           .naval_base_location = 14,
+                           .vic3_infrastructure = 0.F}),
                },
            .province_to_state_id_map =
-               {{1, 1}, {2, 1}, {3, 2}, {4, 2}, {5, 3}, {6, 3}, {7, 4}, {8, 4}, {9, 5}, {10, 5}},
+               {{1, 1}, {2, 1}, {3, 2}, {4, 2}, {5, 3}, {6, 3}, {7, 4}, {8, 4}, {9, 5}, {10, 5}, {12, 6}, {13, 7}},
        });
 
    EXPECT_THAT(railways.railways,
@@ -1233,7 +1259,9 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastr
            Railway(3, {3, 4}),
            Railway(2, {5, 6}),
            Railway(1, {7, 8}),
-           Railway(1, {9, 10})));
+           Railway(1, {9, 10}),
+           Railway(0, {11, 12}),
+           Railway(0, {13, 14})));
 }
 
 

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -1096,12 +1096,22 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
                                  {"0x000003", "mine"},
                              },
                {}}},
+       { "STATE_TWO",
+              vic3::StateRegion{{
+                                    {"0x000011", "city"},
+                                    {"0x000012", "dock"},
+                                    {"0x000013", "mine"},
+                                },
+                  {}} },
    };
 
    const mappers::ProvinceMapper province_mapper{{
                                                      {"0x000001", {1}},
                                                      {"0x000002", {2}},
                                                      {"0x000003", {3}},
+                                                     { "0x000011", {11} },
+                                                     { "0x000012", {12} },
+                                                     { "0x000013", {13} },
                                                  },
        {}};
 
@@ -1111,11 +1121,14 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
                {"1", {"2"}},
                {"2", {"1", "3"}},
                {"3", {"2"}},
+               {"11", {"13"}},
+               {"12", {"13"}},
+               {"13", {"11","12"}},
            },
    }};
 
    const maps::ProvinceDefinitions hoi4_province_definitions{{
-       .land_provinces = {"1", "2", "3"},
+       .land_provinces = {"1", "2", "3", "11", "12", "13"},
    }};
 
    const Railways railways = ConvertRailways(vic3_state_regions,
@@ -1126,11 +1139,12 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
            .states =
                {
                    State(1, StateOptions{.victory_points = {{1, 1}, {3, 1}}, .naval_base_location = 2}),
+            State(1, StateOptions{.victory_points = {{11, 1}, {13, 1}}, .naval_base_location = 12}),
                },
-           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}},
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}, {11, 2}, {12,2}, {13,2}},
        });
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2}), Railway(1, {2, 3})));
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2}), Railway(1, {2, 3}), Railway(1, { 11, 13 }), Railway(1, { 13, 12 })));
 }
 
 

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -1090,6 +1090,109 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
 }
 
 
+TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastructure)
+{
+   const std::map<std::string, vic3::StateRegion> vic3_state_regions{
+       {"STATE_1",
+           vic3::StateRegion{{
+                                 {"0x000001", "city"},
+                                 {"0x000002", "dock"},
+                             },
+               {}}},
+       {"STATE_2",
+           vic3::StateRegion{{
+                                 {"0x000003", "city"},
+                                 {"0x000004", "dock"},
+                             },
+               {}}},
+       {"STATE_3",
+           vic3::StateRegion{{
+                                 {"0x000005", "city"},
+                                 {"0x000006", "dock"},
+                             },
+               {}}},
+       {"STATE_4",
+           vic3::StateRegion{{
+                                 {"0x000007", "city"},
+                                 {"0x000008", "dock"},
+                             },
+               {}}},
+       {"STATE_5",
+           vic3::StateRegion{{
+                                 {"0x000009", "city"},
+                                 {"0x000010", "dock"},
+                             },
+               {}}},
+   };
+
+   const mappers::ProvinceMapper province_mapper{{
+                                                     {"0x000001", {1}},
+                                                     {"0x000002", {2}},
+                                                     {"0x000003", {3}},
+                                                     {"0x000004", {4}},
+                                                     {"0x000005", {5}},
+                                                     {"0x000006", {6}},
+                                                     {"0x000007", {7}},
+                                                     {"0x000008", {8}},
+                                                     {"0x000009", {9}},
+                                                     {"0x000010", {10}},
+                                                 },
+       {}};
+
+   const maps::MapData hoi4_map_data{{
+       .province_neighbors =
+           {
+               {"1", {"2"}},
+               {"3", {"4"}},
+               {"5", {"6"}},
+               {"7", {"8"}},
+               {"9", {"10"}},
+           },
+   }};
+
+   const maps::ProvinceDefinitions hoi4_province_definitions{{
+       .land_provinces = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
+   }};
+
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {
+           .states =
+               {
+                   State(1,
+                       StateOptions{.victory_points = {{1, 1}},
+                           .naval_base_location = 2,
+                           .vic3_infrastructure = 1751.F}),
+                   State(2,
+                       StateOptions{.victory_points = {{3, 1}},
+                           .naval_base_location = 4,
+                           .vic3_infrastructure = 1401.F}),
+                   State(3,
+                       StateOptions{.victory_points = {{5, 1}},
+                           .naval_base_location = 6,
+                           .vic3_infrastructure = 281.F}),
+                   State(4,
+                       StateOptions{.victory_points = {{7, 1}},
+                           .naval_base_location = 8,
+                           .vic3_infrastructure = 166.F}),
+                   State(5,
+                       StateOptions{.victory_points = {{9, 1}}, .naval_base_location = 10, .vic3_infrastructure = 0.F}),
+               },
+           .province_to_state_id_map =
+               {{1, 1}, {2, 1}, {3, 2}, {4, 2}, {5, 3}, {6, 3}, {7, 4}, {8, 4}, {9, 5}, {10, 5}},
+       });
+
+   EXPECT_THAT(railways.railways,
+       testing::ElementsAre(Railway(4, {1, 2}),
+           Railway(3, {3, 4}),
+           Railway(2, {5, 6}),
+           Railway(1, {7, 8}),
+           Railway(1, {9, 10})));
+}
+
+
 TEST(Hoi4worldMapRailwaysConverterTests, RailwayEndpointsAreRecorded)
 {
    const std::map<std::string, vic3::StateRegion> vic3_state_regions{

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -1264,8 +1264,19 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayLevelsAreSetBasedOnStateInfrastr
                            .naval_base_location = 14,
                            .vic3_infrastructure = 0.F}),
                },
-           .province_to_state_id_map =
-               {{1, 1}, {2, 1}, {3, 2}, {4, 2}, {5, 3}, {6, 3}, {7, 4}, {8, 4}, {9, 5}, {10, 5}, {12, 6}, {13, 7}},
+           .province_to_state_id_map = {{1, 1},
+               {2, 1},
+               {3, 2},
+               {4, 2},
+               {5, 3},
+               {6, 3},
+               {7, 4},
+               {8, 4},
+               {9, 5},
+               {10, 5},
+               {12, 6},
+               {13, 7},
+               {14, 8}},
        });
 
    EXPECT_THAT(railways.railways,

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -38,10 +38,19 @@ TEST(Hoi4worldMapRailwaysConverterTests, IntrastateRailwaysAreCreated)
        .land_provinces = {"1", "2", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {
+           .states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}, {3, 1}}, .naval_base_location = 2}),
+               },
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}},
+       });
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {1, 2}), Railway(3, {1, 3})));
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2}), Railway(1, {1, 3})));
 }
 
 
@@ -76,8 +85,15 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoRailwaysThroughNonLandProvinces)
        .land_provinces = {"1", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 3}),
+               },
+           .province_to_state_id_map = {{1, 1}, {3, 1}}});
 
    EXPECT_THAT(railways.railways, testing::ElementsAre());
 }
@@ -113,8 +129,15 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoCityMeansNoIntrastateConnections)
        .land_provinces = {"1", "2", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}, {3, 1}}, .naval_base_location = 2}),
+               },
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}}});
 
    EXPECT_THAT(railways.railways, testing::ElementsAre());
 }
@@ -150,8 +173,15 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoIntrastateRailwaysToSameVic3Province)
        .land_provinces = {"1", "2", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 1}),
+               },
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}}});
 
    EXPECT_THAT(railways.railways, testing::ElementsAre());
 }
@@ -187,8 +217,15 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoIntrastateRailwaysToSameHoi4Province)
        .land_provinces = {"1", "2", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 1}),
+               },
+           .province_to_state_id_map = {{1, 1}}});
 
    EXPECT_THAT(railways.railways, testing::ElementsAre());
 }
@@ -296,10 +333,61 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoIntrastateRailwaysForDisconnectedProv
        .land_provinces = {"1", "2", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}, {3, 1}}, .naval_base_location = 2}),
+               },
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}}});
 
    EXPECT_THAT(railways.railways, testing::ElementsAre());
+}
+
+
+TEST(Hoi4worldMapRailwaysConverterTests, IntrastateRailwaysToNonCityNonDockyardAreTrimmed)
+{
+   const std::map<std::string, vic3::StateRegion> vic3_state_regions{
+       {"STATE_ONE",
+           vic3::StateRegion{{
+                                 {"0x000001", "city"},
+                                 {"0x000002", "dock"},
+                                 {"0x000003", "mine"},
+                             },
+               {}}},
+   };
+
+   const mappers::ProvinceMapper province_mapper{{
+                                                     {"0x000001", {1}},
+                                                     {"0x000002", {2}},
+                                                     {"0x000003", {3}},
+                                                 },
+       {}};
+
+   const maps::MapData hoi4_map_data{{
+       .province_neighbors =
+           {
+               {"1", {"2", "3"}},
+           },
+   }};
+
+   const maps::ProvinceDefinitions hoi4_province_definitions{{
+       .land_provinces = {"1", "2", "3"},
+   }};
+
+   const Railways railways = ConvertRailways(vic3_state_regions,
+       province_mapper,
+       hoi4_map_data,
+       hoi4_province_definitions,
+       {.states =
+               {
+                   State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 2}),
+               },
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}}});
+
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2})));
 }
 
 
@@ -343,12 +431,12 @@ TEST(Hoi4worldMapRailwaysConverterTests, InterstateRailwaysAreCreated)
        .land_provinces = {"1", "10", "100"},
    }};
 
-   const hoi4::States hoi4_states{
+   const States hoi4_states{
        .states =
            {
-               hoi4::State(1, {}),
-               hoi4::State(2, {}),
-               hoi4::State(3, {}),
+               State(1, {.victory_points = {{1, 1}}}),
+               State(2, {.victory_points = {{10, 1}}}),
+               State(3, {.victory_points = {{100, 1}}}),
            },
        .province_to_state_id_map =
            {
@@ -361,7 +449,7 @@ TEST(Hoi4worldMapRailwaysConverterTests, InterstateRailwaysAreCreated)
    const Railways railways =
        ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, hoi4_states);
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {1, 10}), Railway(3, {1, 100})));
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 10}), Railway(1, {1, 100})));
 }
 
 
@@ -398,8 +486,8 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoInterstateRailroadsForNonBorderingSta
        .land_provinces = {"1", "10", "100"},
    }};
 
-   const hoi4::States hoi4_states{
-       .states = {hoi4::State(1, {}), hoi4::State(2, {})},
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{1, 1}}}), State(2, {.victory_points = {{10, 1}}})},
        .province_to_state_id_map =
            {
                {1, 1},
@@ -451,8 +539,8 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoInterstateRailroadsForStatesWithoutSi
        .land_provinces = {"1", "10", "100"},
    }};
 
-   const hoi4::States hoi4_states{
-       .states = {hoi4::State(1, {}), hoi4::State(2, {})},
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{1, 1}}}), State(2, {.victory_points = {{10, 1}}})},
        .province_to_state_id_map =
            {
                {1, 1},
@@ -503,8 +591,8 @@ TEST(Hoi4worldMapRailwaysConverterTests, NoInterstateRailwaysForRepeatedSignific
        .land_provinces = {"1"},
    }};
 
-   const hoi4::States hoi4_states{
-       .states = {hoi4::State(1, {}), hoi4::State(2, {})},
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{1, 1}}}), State(2, {})},
        .province_to_state_id_map =
            {
                {1, 1},
@@ -557,12 +645,12 @@ TEST(Hoi4worldMapRailwaysConverterTests, InterstateRailroadsAreDeduplicated)
        .land_provinces = {"1", "10"},
    }};
 
-   const hoi4::States hoi4_states{
+   const States hoi4_states{
        .states =
            {
-               hoi4::State(1, {}),
-               hoi4::State(2, {}),
-               hoi4::State(3, {}),
+               State(1, {.victory_points = {{1, 1}}}),
+               State(2, {.victory_points = {{10, 1}}}),
+               State(3, {}),
            },
        .province_to_state_id_map =
            {
@@ -574,7 +662,7 @@ TEST(Hoi4worldMapRailwaysConverterTests, InterstateRailroadsAreDeduplicated)
    const Railways railways =
        ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, hoi4_states);
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {1, 10})));
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 10})));
 }
 
 
@@ -626,8 +714,8 @@ TEST(Hoi4worldMapRailwaysConverterTests, LowestCostConnectionFormsInterstateRail
        .land_provinces = {"1", "10", "100", "1000", "2", "20", "3", "30", "300"},
    }};
 
-   const hoi4::States hoi4_states{
-       .states = {hoi4::State(1, {}), hoi4::State(2, {})},
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{2, 1}}}), State(2, {.victory_points = {{20, 1}}})},
        .province_to_state_id_map =
            {
                {1, 1},
@@ -645,7 +733,7 @@ TEST(Hoi4worldMapRailwaysConverterTests, LowestCostConnectionFormsInterstateRail
    const Railways railways =
        ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, hoi4_states);
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {2, 20})));
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {2, 20})));
 }
 
 
@@ -687,10 +775,26 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysPreferShorterPaths)
        .land_provinces = {"1", "2", "3", "10"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{1, 1}, {10, 1}}}), State(2, {})},
+       .province_to_state_id_map =
+           {
+               {1, 1},
+               {100, 1},
+               {2, 1},
+               {3, 1},
+               {300, 1},
+               {10, 2},
+               {1000, 2},
+               {20, 2},
+               {30, 2},
+           },
+   };
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {1, 2, 10})));
+   const Railways railways =
+       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, hoi4_states);
+
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2, 10})));
 }
 
 
@@ -728,10 +832,24 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysPreferFewerProvincesIfDistanceI
        .land_provinces = {"1", "2", "3", "4", "5", "6", "7", "10"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{1, 1}, {10, 1}}})},
+       .province_to_state_id_map =
+           {
+               {1, 1},
+               {2, 1},
+               {3, 1},
+               {4, 1},
+               {6, 1},
+               {7, 1},
+               {10, 1},
+           },
+   };
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {1, 6, 7, 10})));
+   const Railways railways =
+       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, hoi4_states);
+
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 6, 7, 10})));
 }
 
 
@@ -794,6 +912,8 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysPreferEasierTerrains)
    };
    const std::unordered_map<std::string, maps::ProvincePoints> the_province_points = {
        {"100000", maps::ProvincePoints(std::set<maps::Point>{{.x = 1, .y = 0}})},
+       {"1", maps::ProvincePoints(std::set<maps::Point>{{.x = 0, .y = 1}})},
+       {"10", maps::ProvincePoints(std::set<maps::Point>{{.x = 2, .y = 1}})},
        {"2", maps::ProvincePoints(std::set<maps::Point>{{.x = 0, .y = 1}})},
        {"20", maps::ProvincePoints(std::set<maps::Point>{{.x = 2, .y = 1}})},
        {"3", maps::ProvincePoints(std::set<maps::Point>{{.x = 0, .y = 1}})},
@@ -848,6 +968,7 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysPreferEasierTerrains)
        .land_provinces = land_provinces,
        .terrain_types =
            {
+               {"100000", "urban"},
                {"1", "plains"},
                {"10", "urban"},
                {"2", "forest"},
@@ -864,6 +985,14 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysPreferEasierTerrains)
                {"70", "jungle"},
                {"8", "unhandled"},
                {"80", "mountain"},
+               {"100", "urban"},
+               {"200", "urban"},
+               {"300", "urban"},
+               {"400", "urban"},
+               {"500", "urban"},
+               {"600", "urban"},
+               {"700", "urban"},
+               {"800", "urban"},
            },
    });
    const maps::MapData hoi4_map_data{{
@@ -872,22 +1001,48 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysPreferEasierTerrains)
        .province_definitions = province_definitions,
    }};
 
+   const States hoi4_states{
+       .states = {State(1,
+           {.victory_points =
+                   {{100000, 1}, {100, 1}, {200, 1}, {300, 1}, {400, 1}, {500, 1}, {600, 1}, {700, 1}, {800, 1}}})},
+       .province_to_state_id_map =
+           {
+               {10, 1},
+               {20, 1},
+               {30, 1},
+               {40, 1},
+               {50, 1},
+               {60, 1},
+               {70, 1},
+               {80, 1},
+               {100, 1},
+               {200, 1},
+               {300, 1},
+               {400, 1},
+               {500, 1},
+               {600, 1},
+               {700, 1},
+               {800, 1},
+               {100000, 1},
+           },
+   };
+
    const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, province_definitions, {});
+       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, province_definitions, hoi4_states);
 
    EXPECT_THAT(railways.railways,
-       testing::ElementsAre(Railway(3, {100000, 10, 100}),
-           Railway(3, {100000, 20, 200}),
-           Railway(3, {100000, 30, 300}),
-           Railway(3, {100000, 40, 400}),
-           Railway(3, {100000, 50, 500}),
-           Railway(3, {100000, 60, 600}),
-           Railway(3, {100000, 70, 700}),
-           Railway(3, {100000, 80, 800})));
+       testing::ElementsAre(Railway(1, {100000, 10, 100}),
+           Railway(1, {100000, 20, 200}),
+           Railway(1, {100000, 30, 300}),
+           Railway(1, {100000, 40, 400}),
+           Railway(1, {100000, 50, 500}),
+           Railway(1, {100000, 60, 600}),
+           Railway(1, {100000, 70, 700}),
+           Railway(1, {100000, 80, 800})));
 }
 
 
-TEST(Hoi4worldMapRailwaysConverterTests, RailwayEndpointsAreRecoded)
+TEST(Hoi4worldMapRailwaysConverterTests, RailwayEndpointsAreRecorded)
 {
    const std::map<std::string, vic3::StateRegion> vic3_state_regions{
        {"STATE_ONE",
@@ -917,10 +1072,20 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwayEndpointsAreRecoded)
        .land_provinces = {"1", "2", "3"},
    }};
 
-   const Railways railways =
-       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, {});
+   const States hoi4_states{
+       .states = {State(1, {.victory_points = {{1, 1}, {2, 1}, {3, 1}}})},
+       .province_to_state_id_map =
+           {
+               {1, 1},
+               {2, 1},
+               {3, 1},
+           },
+   };
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(3, {1, 2}), Railway(3, {1, 3})));
+   const Railways railways =
+       ConvertRailways(vic3_state_regions, province_mapper, hoi4_map_data, hoi4_province_definitions, hoi4_states);
+
+   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2}), Railway(1, {1, 3})));
    EXPECT_THAT(railways.railway_endpoints, testing::ElementsAre(1, 2, 3));
 }
 

--- a/src/hoi4_world/map/railways_converter_tests.cpp
+++ b/src/hoi4_world/map/railways_converter_tests.cpp
@@ -401,12 +401,20 @@ TEST(Hoi4worldMapRailwaysConverterTests, IntrastateRailwaysToNonCityNonDockyardA
                                  {"0x000003", "mine"},
                              },
                {}}},
+       {"STATE_TWO",
+           vic3::StateRegion{{
+                                 {"0x000011", "city"},
+                                 {"0x000012", "dock"},
+                             },
+               {}}},
    };
 
    const mappers::ProvinceMapper province_mapper{{
                                                      {"0x000001", {1}},
                                                      {"0x000002", {2}},
                                                      {"0x000003", {3}},
+                                                     {"0x000011", {11}},
+                                                     {"0x000012", {12}},
                                                  },
        {}};
 
@@ -414,11 +422,12 @@ TEST(Hoi4worldMapRailwaysConverterTests, IntrastateRailwaysToNonCityNonDockyardA
        .province_neighbors =
            {
                {"1", {"2", "3"}},
+               {"11", {"12"}},
            },
    }};
 
    const maps::ProvinceDefinitions hoi4_province_definitions{{
-       .land_provinces = {"1", "2", "3"},
+       .land_provinces = {"1", "2", "3", "11", "12"},
    }};
 
    const Railways railways = ConvertRailways(vic3_state_regions,
@@ -428,8 +437,9 @@ TEST(Hoi4worldMapRailwaysConverterTests, IntrastateRailwaysToNonCityNonDockyardA
        {.states =
                {
                    State(1, StateOptions{.victory_points = {{1, 1}}, .naval_base_location = 2}),
+                   State(2, StateOptions{.victory_points = {{12, 1}}, .naval_base_location = 12}),
                },
-           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}}});
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}, {11, 1}, {12, 1}, {13, 1}}});
 
    EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2})));
 }
@@ -1096,22 +1106,22 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
                                  {"0x000003", "mine"},
                              },
                {}}},
-       { "STATE_TWO",
-              vic3::StateRegion{{
-                                    {"0x000011", "city"},
-                                    {"0x000012", "dock"},
-                                    {"0x000013", "mine"},
-                                },
-                  {}} },
+       {"STATE_TWO",
+           vic3::StateRegion{{
+                                 {"0x000011", "city"},
+                                 {"0x000012", "dock"},
+                                 {"0x000013", "mine"},
+                             },
+               {}}},
    };
 
    const mappers::ProvinceMapper province_mapper{{
                                                      {"0x000001", {1}},
                                                      {"0x000002", {2}},
                                                      {"0x000003", {3}},
-                                                     { "0x000011", {11} },
-                                                     { "0x000012", {12} },
-                                                     { "0x000013", {13} },
+                                                     {"0x000011", {11}},
+                                                     {"0x000012", {12}},
+                                                     {"0x000013", {13}},
                                                  },
        {}};
 
@@ -1123,7 +1133,7 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
                {"3", {"2"}},
                {"11", {"13"}},
                {"12", {"13"}},
-               {"13", {"11","12"}},
+               {"13", {"11", "12"}},
            },
    }};
 
@@ -1139,12 +1149,13 @@ TEST(Hoi4worldMapRailwaysConverterTests, RailwaysSharingRouteAreMerged)
            .states =
                {
                    State(1, StateOptions{.victory_points = {{1, 1}, {3, 1}}, .naval_base_location = 2}),
-            State(1, StateOptions{.victory_points = {{11, 1}, {13, 1}}, .naval_base_location = 12}),
+                   State(1, StateOptions{.victory_points = {{11, 1}, {13, 1}}, .naval_base_location = 12}),
                },
-           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}, {11, 2}, {12,2}, {13,2}},
+           .province_to_state_id_map = {{1, 1}, {2, 1}, {3, 1}, {11, 2}, {12, 2}, {13, 2}},
        });
 
-   EXPECT_THAT(railways.railways, testing::ElementsAre(Railway(1, {1, 2}), Railway(1, {2, 3}), Railway(1, { 11, 13 }), Railway(1, { 13, 12 })));
+   EXPECT_THAT(railways.railways,
+       testing::ElementsAre(Railway(1, {1, 2}), Railway(1, {2, 3}), Railway(1, {11, 13}), Railway(1, {13, 12})));
 }
 
 

--- a/src/hoi4_world/states/hoi4_state.h
+++ b/src/hoi4_world/states/hoi4_state.h
@@ -31,6 +31,8 @@ struct StateOptions
    std::optional<int> naval_base_location;
    std::optional<int> naval_base_level;
    std::set<std::string> cores;
+
+   float vic3_infrastructure = 0.0F;
 };
 
 
@@ -50,7 +52,8 @@ class State
        dockyards_(state_options.dockyards),
        naval_base_location_(state_options.naval_base_location),
        naval_base_level_(state_options.naval_base_level),
-       cores_(state_options.cores)
+       cores_(state_options.cores),
+       vic3_infrastructure_(state_options.vic3_infrastructure)
    {
    }
 
@@ -67,6 +70,7 @@ class State
    [[nodiscard]] std::optional<int> GetNavalBaseLocation() const { return naval_base_location_; }
    [[nodiscard]] std::optional<int> GetNavalBaseLevel() const { return naval_base_level_; }
    [[nodiscard]] std::set<std::string> GetCores() const { return cores_; }
+   [[nodiscard]] float GetVic3Infrastructure() const { return vic3_infrastructure_; }
 
    void SetHighestVictoryPointValue(int value);
 
@@ -88,6 +92,8 @@ class State
    std::optional<int> naval_base_location_;
    std::optional<int> naval_base_level_;
    std::set<std::string> cores_;
+
+   float vic3_infrastructure_ = 0.0F;
 };
 
 }  // namespace hoi4

--- a/src/hoi4_world/states/hoi4_states_converter.cpp
+++ b/src/hoi4_world/states/hoi4_states_converter.cpp
@@ -883,7 +883,8 @@ hoi4::States CreateStates(const std::map<int, vic3::State>& vic3_states,
                  .dockyards = dockyards,
                  .naval_base_location = naval_base_location,
                  .naval_base_level = naval_base_level,
-                 .cores = cores});
+                 .cores = cores,
+                 .vic3_infrastructure = vic3_state_itr->second.GetInfrastructure()});
       }
       for (const auto& province_set: final_wasteland_connected_province_sets)
       {

--- a/src/hoi4_world/world/hoi4_world_converter_tests.cpp
+++ b/src/hoi4_world/world/hoi4_world_converter_tests.cpp
@@ -480,11 +480,31 @@ TEST(Hoi4worldWorldHoi4worldconverter, BuildingsAreCreated)
 TEST(Hoi4worldWorldHoi4worldconverter, RailwaysAreCreated)
 {
    const vic3::StateRegion vic3_state_region({{"0x000001", "city"}, {"0x000002", "port"}, {"0x000003", "mine"}}, {});
+
+   const auto province_definitions = vic3::ProvinceDefinitions({
+       "0x000001",
+       "0x000002",
+       "0x000003",
+       "0x000004",
+       "0x000005",
+       "0x000006",
+   });
+
    const vic3::World source_world({
+       .states =
+           {
+               {1,
+                   vic3::State({
+                       .owner_number = 1,
+                       .owner_tag = "TAG",
+                       .provinces = {1, 2, 3},
+                   })},
+           },
        .state_regions =
            {
                {"state", vic3_state_region},
            },
+       .province_definitions = province_definitions,
    });
 
    const mappers::CountryMapper country_mapper;

--- a/src/out_hoi4/map/out_railways.cpp
+++ b/src/out_hoi4/map/out_railways.cpp
@@ -18,7 +18,10 @@ void out::OutputRailways(std::string_view output_name, const std::vector<hoi4::R
 
    for (const auto& railway: railways)
    {
-      out << railway;
+      if (railway.GetLevel() > 0)
+      {
+         out << railway;
+      }
    }
 
    out.close();

--- a/src/out_hoi4/map/out_railways_tests.cpp
+++ b/src/out_hoi4/map/out_railways_tests.cpp
@@ -45,6 +45,7 @@ TEST(Outhoi4MapOutrailwaysTests, RailwaysAreOutput)
        {
            hoi4::Railway{1, {1, 2}},
            hoi4::Railway{2, {2, 4, 8}},
+           hoi4::Railway{0, {3, 9, 27}},
        });
 
    ASSERT_TRUE(commonItems::DoesFileExist("output/Outhoi4MapBuildingsTestsRailwaysAreOutput/map/railways.txt"));

--- a/src/vic3_world/states/vic3_state.h
+++ b/src/vic3_world/states/vic3_state.h
@@ -15,6 +15,7 @@ struct StateOptions
    std::optional<int> owner_number;
    std::optional<std::string> owner_tag;
    bool incorporated = false;
+   float infrastructure = 0.0F;
    std::set<int> provinces;
    int population = 0;
    int employed_population = 0;
@@ -29,6 +30,7 @@ class State
        owner_number_(state_options.owner_number),
        owner_tag_(std::move(state_options.owner_tag)),
        incorporated_(state_options.incorporated),
+       infrastructure_(state_options.infrastructure),
        provinces_(std::move(state_options.provinces)),
        population_(state_options.population),
        employed_population_(state_options.employed_population)
@@ -38,6 +40,7 @@ class State
    [[nodiscard]] const std::optional<int>& GetOwnerNumber() const { return owner_number_; }
    [[nodiscard]] const std::optional<std::string>& GetOwnerTag() const { return owner_tag_; }
    [[nodiscard]] bool IsIncorporated() const { return incorporated_; }
+   [[nodiscard]] float GetInfrastructure() const { return infrastructure_; }
    [[nodiscard]] const std::set<int>& GetProvinces() const { return provinces_; }
    [[nodiscard]] int GetPopulation() const { return population_; }
    [[nodiscard]] int GetEmployedPopulation() const { return employed_population_; }
@@ -50,6 +53,7 @@ class State
    std::optional<int> owner_number_;
    std::optional<std::string> owner_tag_;
    bool incorporated_ = false;
+   float infrastructure_ = 0.0F;
    std::set<int> provinces_;
    int population_ = 0;
    int employed_population_ = 0;

--- a/src/vic3_world/states/vic3_state_importer.cpp
+++ b/src/vic3_world/states/vic3_state_importer.cpp
@@ -16,6 +16,9 @@ vic3::StateImporter::StateImporter()
          incorporated_ = true;
       }
    });
+   state_parser_.registerKeyword("infrastructure", [this](std::istream& input_stream) {
+      infrastructure_ = static_cast<float>(commonItems::getDouble(input_stream));
+   });
    state_parser_.registerKeyword("provinces", [this](std::istream& input_stream) {
       provinces_parser_.parseStream(input_stream);
    });
@@ -92,6 +95,7 @@ vic3::State vic3::StateImporter::ImportState(std::istream& input_stream)
 {
    owner_number_.reset();
    incorporated_ = false;
+   infrastructure_ = 0.0F;
    provinces_.clear();
    population_ = 0;
    employed_population_ = 0;
@@ -100,6 +104,7 @@ vic3::State vic3::StateImporter::ImportState(std::istream& input_stream)
 
    return State({.owner_number = owner_number_,
        .incorporated = incorporated_,
+       .infrastructure = infrastructure_,
        .provinces = provinces_,
        .population = population_,
        .employed_population = employed_population_});

--- a/src/vic3_world/states/vic3_state_importer.h
+++ b/src/vic3_world/states/vic3_state_importer.h
@@ -28,6 +28,7 @@ class StateImporter
 
    std::optional<int> owner_number_;
    bool incorporated_ = false;
+   float infrastructure_ = 0.0F;
    std::set<int> provinces_;
    int population_ = 0;
    int employed_population_ = 0;

--- a/src/vic3_world/states/vic3_state_importer_tests.cpp
+++ b/src/vic3_world/states/vic3_state_importer_tests.cpp
@@ -17,6 +17,7 @@ TEST(Vic3worldStateVic3stateimporter, DefaultsAreDefaulted)
    EXPECT_FALSE(state.GetOwnerNumber().has_value());
    EXPECT_FALSE(state.GetOwnerTag().has_value());
    EXPECT_FALSE(state.IsIncorporated());
+   EXPECT_NEAR(state.GetInfrastructure(), 0.0F, 0.0001F);
    EXPECT_TRUE(state.GetProvinces().empty());
    EXPECT_EQ(state.GetPopulation(), 0);
    EXPECT_EQ(state.GetEmployedPopulation(), 0);
@@ -42,6 +43,7 @@ TEST(Vic3worldStateVic3stateimporter, ItemsCanBeInput)
    input << "={\n";
    input << "\tcountry=42\n";
    input << "\tincorporation = 1\n";
+   input << "\tinfrastructure = 123.45\n";
    input << "\tprovinces={\n";
    input << "\t\tprovinces = { 37330 1 37333 9 37348 1 }\n";
    input << "\t}";
@@ -62,6 +64,7 @@ TEST(Vic3worldStateVic3stateimporter, ItemsCanBeInput)
    EXPECT_EQ(state.GetOwnerNumber(), 42);
    EXPECT_FALSE(state.GetOwnerTag().has_value());
    EXPECT_TRUE(state.IsIncorporated());
+   EXPECT_NEAR(state.GetInfrastructure(), 123.45F, 0.0001F);
    EXPECT_THAT(state.GetProvinces(),
        testing::UnorderedElementsAre(37330,
            37331,
@@ -122,6 +125,8 @@ TEST(Vic3worldStateVic3stateimporter, MultipleStatesCanBeInput)
    std::stringstream input_one;
    input_one << "={\n";
    input_one << "\tcountry=42\n";
+   input_one << "\tincorporation = 1\n";
+   input_one << "\tinfrastructure = 123.45\n";
    input_one << "\tprovinces={\n";
    input_one << "\t\tprovinces = { 37330 1 37333 9 37348 1 }\n";
    input_one << "\t}";
@@ -142,6 +147,8 @@ TEST(Vic3worldStateVic3stateimporter, MultipleStatesCanBeInput)
 
    EXPECT_EQ(state_one.GetOwnerNumber(), 42);
    EXPECT_FALSE(state_one.GetOwnerTag().has_value());
+   EXPECT_TRUE(state_one.IsIncorporated());
+   EXPECT_NEAR(state_one.GetInfrastructure(), 123.45F, 0.0001F);
    EXPECT_THAT(state_one.GetProvinces(),
        testing::UnorderedElementsAre(37330,
            37331,
@@ -162,6 +169,8 @@ TEST(Vic3worldStateVic3stateimporter, MultipleStatesCanBeInput)
 
    EXPECT_FALSE(state_two.GetOwnerNumber().has_value());
    EXPECT_FALSE(state_two.GetOwnerTag().has_value());
+   EXPECT_FALSE(state_two.IsIncorporated());
+   EXPECT_NEAR(state_two.GetInfrastructure(), 0.0F, 0.0001F);
    EXPECT_TRUE(state_two.GetProvinces().empty());
    EXPECT_EQ(state_two.GetPopulation(), 0);
    EXPECT_EQ(state_two.GetEmployedPopulation(), 0);


### PR DESCRIPTION
Towards #73 

* When multiple railways share a stretch, make that a separate railway.
* Remove railways to nowhere.
* Improve path cost calculations
* First steps towards setting railway levels