### PR TITLE
Tag priorities

### DIFF
--- a/Vic3ToHoI4Tests.vcxproj
+++ b/Vic3ToHoI4Tests.vcxproj
@@ -80,7 +80,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ProgramDataBaseFileName>$(SolutionDir)lib\common.pdb</ProgramDataBaseFileName>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
-      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(SolutionDir)lib\pch.pch</PrecompiledHeaderOutputFile>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>

--- a/Vic3ToHoI4lib.vcxproj
+++ b/Vic3ToHoI4lib.vcxproj
@@ -323,7 +323,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderOutputFile>$(SolutionDir)lib\pch.pch</PrecompiledHeaderOutputFile>
-      <ProgramDataBaseFileName>$(SolutionDir)lib\common.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(SolutionDir)lib\Vic3ToHoI4lib.pdb</ProgramDataBaseFileName>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <Optimization>Disabled</Optimization>
     </ClCompile>

--- a/src/mappers/country/country_mapper.h
+++ b/src/mappers/country/country_mapper.h
@@ -16,11 +16,9 @@ class CountryMapper
 {
   public:
    CountryMapper() = default;
-   explicit CountryMapper(std::map<int, std::string>&& country_mappings): country_mappings_(std::move(country_mappings))
+   explicit CountryMapper(std::map<int, std::string> country_mappings): country_mappings_(std::move(country_mappings))
    {
    }
-   explicit CountryMapper(const std::map<int, std::string>& country_mappings): country_mappings_(country_mappings) {}
-
    [[nodiscard]] std::optional<std::string> GetHoiTag(const int& vic_number) const;
 
    [[nodiscard]] const std::map<int, std::string>& GetCountryMappings() const { return country_mappings_; }

--- a/src/mappers/country/country_mapper.h
+++ b/src/mappers/country/country_mapper.h
@@ -19,9 +19,7 @@ class CountryMapper
    explicit CountryMapper(std::map<int, std::string>&& country_mappings): country_mappings_(std::move(country_mappings))
    {
    }
-   explicit CountryMapper(const std::map<int, std::string>& country_mappings): country_mappings_(country_mappings)
-   {
-   }
+   explicit CountryMapper(const std::map<int, std::string>& country_mappings): country_mappings_(country_mappings) {}
 
    [[nodiscard]] std::optional<std::string> GetHoiTag(const int& vic_number) const;
 

--- a/src/mappers/country/country_mapper.h
+++ b/src/mappers/country/country_mapper.h
@@ -16,7 +16,10 @@ class CountryMapper
 {
   public:
    CountryMapper() = default;
-   explicit CountryMapper(std::map<int, std::string> country_mappings): country_mappings_(std::move(country_mappings))
+   explicit CountryMapper(std::map<int, std::string>&& country_mappings): country_mappings_(std::move(country_mappings))
+   {
+   }
+   explicit CountryMapper(const std::map<int, std::string>& country_mappings): country_mappings_(country_mappings)
    {
    }
 

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -54,6 +54,8 @@ mappers::CountryMapper mappers::CreateCountryMappings(std::string_view country_m
    int tag_suffix = 0;
 
    std::vector<const vic3::Country*> deferred_map_countries = {};
+   // civil war countries are very last.
+   std::vector<const vic3::Country*> civilwar_map_countries = {};
 
    std::set<std::string> used_hoi4_tags;
    for (const vic3::Country& country: countries | std::views::values)
@@ -65,13 +67,50 @@ mappers::CountryMapper mappers::CreateCountryMappings(std::string_view country_m
       {
          country_mappings.emplace(country.GetNumber(), mappingRule->second);
       }
+      else if (!country.IsCivilWarCountry())
+      {
+         deferred_map_countries.emplace_back(&country);
+      }
       else
       {
-         deferred_map_countries.push_back(&country);
+         civilwar_map_countries.emplace_back(&country);
       }
    }
 
    for (const auto& country: deferred_map_countries)
+   {
+      const auto& vic3_tag = country->GetTag();
+      // first, attempt to map the default rule again. This will trigger for civil war countries
+      //  that have a different tag from their parent country.
+      const auto& mappingRule = country_mapping_rules.find(vic3_tag);
+      if (mappingRule != country_mapping_rules.end() && used_hoi4_tags.emplace(mappingRule->second).second)
+      {
+         country_mappings.emplace(country->GetNumber(), vic3_tag);
+      }
+      // if that doesn't work, try to use vic3 country tag next
+      else if (vic3_tag.length() == 3 && used_hoi4_tags.emplace(vic3_tag).second)
+      {
+         country_mappings.emplace(country->GetNumber(), vic3_tag);
+      }
+      else
+      {
+         std::string possible_hoi4_tag = fmt::format("{}{:0>2}", tag_prefix, tag_suffix);
+         while (used_hoi4_tags.contains(possible_hoi4_tag))
+         {
+            ++tag_suffix;
+            if (tag_suffix > 99)
+            {
+               tag_suffix = 0;
+               --tag_prefix;
+            }
+            possible_hoi4_tag = fmt::format("{}{:0>2}", tag_prefix, tag_suffix);
+         }
+         country_mappings.emplace(country->GetNumber(), possible_hoi4_tag);
+         used_hoi4_tags.emplace(possible_hoi4_tag);
+      }
+   }
+
+   for (const auto& country: civilwar_map_countries)
    {
       const auto& vic3_tag = country->GetTag();
       // first, attempt to map the default rule again. This will trigger for civil war countries

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -13,7 +13,7 @@
 namespace
 {
 
-std::map<std::string, std::string> ImportMappingRules(std::string_view country_mappings_file)
+std::map<std::string, std::string>&& ImportMappingRules(std::string_view country_mappings_file)
 {
    std::map<std::string, std::string> country_mapping_rules;  // vic3 tag -> hoi4 tag
 
@@ -38,20 +38,20 @@ std::map<std::string, std::string> ImportMappingRules(std::string_view country_m
 
    country_mappings_parser.parseFile(country_mappings_file);
 
-   return country_mapping_rules;
+   return std::move(country_mapping_rules);
 }
 
 /// Class so that different mapping strategies can share global variables like country_mappings and
 /// country_mapping_rules
 class CountryMappingCreator
 {
-   std::map<int, std::string> country_mappings = {};
-   std::map<std::string, std::string> country_mapping_rules;
-   std::vector<const vic3::Country*> deferred_map_countries = {};
+   std::map<int, std::string> country_mappings_ = {};
+   std::map<std::string, std::string> country_mapping_rules_;
+   std::vector<const vic3::Country*> deferred_map_countries_ = {};
 
-   std::set<std::string> used_hoi4_tags = {};
-   char tag_prefix = 'Z';
-   int tag_suffix = 0;
+   std::set<std::string> used_hoi4_tags_ = {};
+   char tag_prefix_ = 'Z';
+   int tag_suffix_ = 0;
 
    // note: these are static because of bound function weirdness
 
@@ -60,7 +60,7 @@ class CountryMappingCreator
    {
       if (country.IsCivilWarCountry())
       {
-         this_->deferred_map_countries.push_back(&country);
+         this_->deferred_map_countries_.push_back(&country);
          return true;
       }
       return false;
@@ -73,11 +73,11 @@ class CountryMappingCreator
    static bool AddCountryWithRule(CountryMappingCreator* this_, const vic3::Country& country)
    {
       const auto& vic3_tag = country.GetTag();
-      const auto& mappingRule = this_->country_mapping_rules.find(vic3_tag);
-      if (mappingRule != this_->country_mapping_rules.end() &&
-          this_->used_hoi4_tags.emplace(mappingRule->second).second)
+      const auto& mappingRule = this_->country_mapping_rules_.find(vic3_tag);
+      if (mappingRule != this_->country_mapping_rules_.end() &&
+          this_->used_hoi4_tags_.emplace(mappingRule->second).second)
       {
-         this_->country_mappings.emplace(country.GetNumber(), mappingRule->second);
+         this_->country_mappings_.emplace(country.GetNumber(), mappingRule->second);
          return true;
       }
       return false;
@@ -86,7 +86,7 @@ class CountryMappingCreator
    // Countries should always be deferred.
    static bool DeferCountryAlways(CountryMappingCreator* this_, const vic3::Country& country)
    {
-      this_->deferred_map_countries.push_back(&country);
+      this_->deferred_map_countries_.push_back(&country);
       return true;
    }
 
@@ -94,9 +94,9 @@ class CountryMappingCreator
    static bool AddCountryWithVicId(CountryMappingCreator* this_, const vic3::Country& country)
    {
       const auto vic3_tag = country.GetTag();
-      if (vic3_tag.length() == 3 && this_->used_hoi4_tags.emplace(vic3_tag).second)
+      if (vic3_tag.length() == 3 && this_->used_hoi4_tags_.emplace(vic3_tag).second)
       {
-         this_->country_mappings.emplace(country.GetNumber(), vic3_tag);
+         this_->country_mappings_.emplace(country.GetNumber(), vic3_tag);
          return true;
       }
       return false;
@@ -108,23 +108,23 @@ class CountryMappingCreator
       std::string possible_hoi4_tag;
       do
       {
-         possible_hoi4_tag = fmt::format("{}{:0>2}", this_->tag_prefix, this_->tag_suffix);
-         ++this_->tag_suffix;
-         if (this_->tag_suffix > 99)
+         possible_hoi4_tag = fmt::format("{}{:0>2}", this_->tag_prefix_, this_->tag_suffix_);
+         ++this_->tag_suffix_;
+         if (this_->tag_suffix_ > 99)
          {
-            this_->tag_suffix = 0;
-            --this_->tag_prefix;
+            this_->tag_suffix_ = 0;
+            --this_->tag_prefix_;
          }
-      } while (this_->used_hoi4_tags.contains(possible_hoi4_tag));
-      this_->country_mappings.emplace(country.GetNumber(), possible_hoi4_tag);
-      this_->used_hoi4_tags.emplace(possible_hoi4_tag);
+      } while (this_->used_hoi4_tags_.contains(possible_hoi4_tag));
+      this_->country_mappings_.emplace(country.GetNumber(), possible_hoi4_tag);
+      this_->used_hoi4_tags_.emplace(possible_hoi4_tag);
       return true;
    }
 
    // Attempt to name (or defer naming of) a country. Only the first successful strategy will be used.
-   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<CountryStrategyFn*> strategies)
+   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<CountryStrategyFn*>&& strategies)
    {
-      for (decltype(strategies)::const_iterator strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
+      for (auto strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
       {
          if ((**strategy)(this, country))
          {
@@ -134,35 +134,38 @@ class CountryMappingCreator
    }
 
   public:
-   CountryMappingCreator(std::string_view country_mappings_file):
-       country_mapping_rules(ImportMappingRules(country_mappings_file))
+   explicit CountryMappingCreator(std::string_view country_mappings_file):
+       country_mapping_rules_(ImportMappingRules(country_mappings_file))
    {
    }
 
    // Where the logic happens
    std::map<int, std::string>&& AssignTags(auto countries)
    {
+      country_mappings_.clear();
+      tag_prefix_ = 'Z';
+      tag_suffix_ = 0;
       for (const auto& country: countries)
       {
          ExecuteStrategiesForCountry(country, {DeferCountryWithCivilWar, AddCountryWithRule, DeferCountryAlways});
       }
 
       // after we got the initial rule countries, try again via vicId and then Znn
-      std::vector<const vic3::Country*> currentDeferredCountries = std::move(deferred_map_countries);
-      deferred_map_countries = {};
+      std::vector<const vic3::Country*> currentDeferredCountries(std::move(deferred_map_countries_));
+      deferred_map_countries_.clear();
       for (const auto& country: currentDeferredCountries)
       {
          ExecuteStrategiesForCountry(*country, {DeferCountryWithCivilWar, AddCountryWithVicId, AddCountryWithZ});
       }
       // finally try the civil war countries
-      currentDeferredCountries = std::move(deferred_map_countries);
-      deferred_map_countries = {};
+      currentDeferredCountries = std::move(deferred_map_countries_);
+      deferred_map_countries_.clear();
       for (const auto& country: currentDeferredCountries)
       {
          ExecuteStrategiesForCountry(*country, {AddCountryWithRule, AddCountryWithVicId, AddCountryWithZ});
       }
 
-      return std::move(country_mappings);
+      return std::move(country_mappings_);
    }
 };
 

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -126,7 +126,7 @@ class CountryMappingCreator
    {
       for (decltype(strategies)::const_iterator strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
       {
-         if ((**strategy)(this,country))
+         if ((**strategy)(this, country))
          {
             return;
          }

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -53,84 +53,14 @@ class CountryMappingCreator
    char tag_prefix_ = 'Z';
    int tag_suffix_ = 0;
 
-   // note: these are static because of bound function weirdness
-
-   // Rebel countries should be deferred to give priority to non-rebel countries.
-   static bool DeferCountryWithCivilWar(CountryMappingCreator* this_, const vic3::Country& country)
-   {
-      if (country.IsCivilWarCountry())
-      {
-         this_->deferred_map_countries_.push_back(&country);
-         return true;
-      }
-      return false;
-   }
-
-   // decltype this because function types are a pain to write out
-   using CountryStrategyFn = decltype(DeferCountryWithCivilWar);
-
-   // Countries with an existing rule should be converted.
-   static bool AddCountryWithRule(CountryMappingCreator* this_, const vic3::Country& country)
-   {
-      const auto& vic3_tag = country.GetTag();
-      const auto& mappingRule = this_->country_mapping_rules_.find(vic3_tag);
-      if (mappingRule != this_->country_mapping_rules_.end() &&
-          this_->used_hoi4_tags_.emplace(mappingRule->second).second)
-      {
-         this_->country_mappings_.emplace(country.GetNumber(), mappingRule->second);
-         return true;
-      }
-      return false;
-   }
-
-   // Countries should always be deferred.
-   static bool DeferCountryAlways(CountryMappingCreator* this_, const vic3::Country& country)
-   {
-      this_->deferred_map_countries_.push_back(&country);
-      return true;
-   }
-
-   // Countries should be added via their vic3 tag.
-   static bool AddCountryWithVicId(CountryMappingCreator* this_, const vic3::Country& country)
-   {
-      const auto vic3_tag = country.GetTag();
-      if (vic3_tag.length() == 3 && this_->used_hoi4_tags_.emplace(vic3_tag).second)
-      {
-         this_->country_mappings_.emplace(country.GetNumber(), vic3_tag);
-         return true;
-      }
-      return false;
-   }
-
-   // Countries should be added with Znn naming scheme. This always succeeds.
-   static bool AddCountryWithZ(CountryMappingCreator* this_, const vic3::Country& country)
-   {
-      std::string possible_hoi4_tag;
-      do
-      {
-         possible_hoi4_tag = fmt::format("{}{:0>2}", this_->tag_prefix_, this_->tag_suffix_);
-         ++this_->tag_suffix_;
-         if (this_->tag_suffix_ > 99)
-         {
-            this_->tag_suffix_ = 0;
-            --this_->tag_prefix_;
-         }
-      } while (this_->used_hoi4_tags_.contains(possible_hoi4_tag));
-      this_->country_mappings_.emplace(country.GetNumber(), possible_hoi4_tag);
-      this_->used_hoi4_tags_.emplace(possible_hoi4_tag);
-      return true;
-   }
+   using StrategyFn = std::function<bool(const vic3::Country&)>;
 
    // Attempt to name (or defer naming of) a country. Only the first successful strategy will be used.
-   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<CountryStrategyFn*>&& strategies)
+   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<StrategyFn>&& strategies)
    {
-      for (auto strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
-      {
-         if ((**strategy)(this, country))
-         {
-            return;
-         }
-      }
+      static_cast<void>(std::any_of(strategies.begin(), strategies.end(), [country](StrategyFn fn) {
+         return fn(country);
+      }));
    }
 
   public:
@@ -145,6 +75,66 @@ class CountryMappingCreator
       country_mappings_.clear();
       tag_prefix_ = 'Z';
       tag_suffix_ = 0;
+
+      // Rebel countries should be deferred to give priority to non-rebel countries.
+      StrategyFn DeferCountryWithCivilWar = [this](const vic3::Country& country) {
+         if (country.IsCivilWarCountry())
+         {
+            this->deferred_map_countries_.push_back(&country);
+            return true;
+         }
+         return false;
+      };
+
+      // Countries with an existing rule should be converted.
+      StrategyFn AddCountryWithRule = [this](const vic3::Country& country) {
+         const auto& vic3_tag = country.GetTag();
+         const auto& mappingRule = this->country_mapping_rules_.find(vic3_tag);
+         if (mappingRule != this->country_mapping_rules_.end() &&
+             this->used_hoi4_tags_.emplace(mappingRule->second).second)
+         {
+            this->country_mappings_.emplace(country.GetNumber(), mappingRule->second);
+            return true;
+         }
+         return false;
+      };
+
+      // Countries should always be deferred.
+      StrategyFn DeferCountryAlways = [this](const vic3::Country& country) {
+         this->deferred_map_countries_.push_back(&country);
+         return true;
+      };
+
+      // Countries should be added via their vic3 tag.
+      StrategyFn AddCountryWithVicId = [this](const vic3::Country& country) {
+         const auto vic3_tag = country.GetTag();
+         if (vic3_tag.length() == 3 && this->used_hoi4_tags_.emplace(vic3_tag).second)
+         {
+            this->country_mappings_.emplace(country.GetNumber(), vic3_tag);
+            return true;
+         }
+         return false;
+      };
+
+      // Countries should be added with Znn naming scheme. This always succeeds.
+      StrategyFn AddCountryWithZ = [this](const vic3::Country& country) {
+         std::string possible_hoi4_tag;
+         do
+         {
+            possible_hoi4_tag = fmt::format("{}{:0>2}", this->tag_prefix_, this->tag_suffix_);
+            ++this->tag_suffix_;
+            if (this->tag_suffix_ > 99)
+            {
+               this->tag_suffix_ = 0;
+               --this->tag_prefix_;
+            }
+         } while (this->used_hoi4_tags_.contains(possible_hoi4_tag));
+         this->country_mappings_.emplace(country.GetNumber(), possible_hoi4_tag);
+         this->used_hoi4_tags_.emplace(possible_hoi4_tag);
+         return true;
+      };
+
+
       for (const auto& country: countries)
       {
          ExecuteStrategiesForCountry(country, {DeferCountryWithCivilWar, AddCountryWithRule, DeferCountryAlways});

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -52,13 +52,71 @@ class CountryMappingCreator
    std::set<std::string> used_hoi4_tags_ = {};
    char tag_prefix_ = 'Z';
    int tag_suffix_ = 0;
+  
+   using CountryStrategyFn = std::function<bool(const vic3::Country&)>;
 
-   using StrategyFn = std::function<bool(const vic3::Country&)>;
+   // Rebel countries should be deferred to give priority to non-rebel countries.
+   const CountryStrategyFn DeferCountryWithCivilWar = [this](const vic3::Country& country) -> bool {
+      if (country.IsCivilWarCountry())
+      {
+         this->deferred_map_countries_.push_back(&country);
+         return true;
+      }
+      return false;
+   };
+
+   // Countries with an existing rule should be converted.
+   const CountryStrategyFn AddCountryWithRule = [this](const vic3::Country& country) -> bool {
+      const auto& vic3_tag = country.GetTag();
+      const auto& mappingRule = this->country_mapping_rules_.find(vic3_tag);
+      if (mappingRule != this->country_mapping_rules_.end() &&
+          this->used_hoi4_tags_.emplace(mappingRule->second).second)
+      {
+         this->country_mappings_.emplace(country.GetNumber(), mappingRule->second);
+         return true;
+      }
+      return false;
+   };
+
+   // Countries should always be deferred.
+   const CountryStrategyFn DeferCountryAlways = [this](const vic3::Country& country) -> bool {
+      this->deferred_map_countries_.push_back(&country);
+      return true;
+   };
+
+   // Countries should be added via their vic3 tag.
+   const CountryStrategyFn AddCountryWithVicId = [this](const vic3::Country& country) -> bool {
+      const auto& vic3_tag = country.GetTag();
+      if (vic3_tag.length() == 3 && this->used_hoi4_tags_.emplace(vic3_tag).second)
+      {
+         this->country_mappings_.emplace(country.GetNumber(), vic3_tag);
+         return true;
+      }
+      return false;
+   };
+
+   // Countries should be added with Znn naming scheme. This always succeeds.
+   const CountryStrategyFn AddCountryWithZ = [this](const vic3::Country& country) -> bool {
+      std::string possible_hoi4_tag;
+      do
+      {
+         possible_hoi4_tag = fmt::format("{}{:0>2}", this->tag_prefix_, this->tag_suffix_);
+         ++this->tag_suffix_;
+         if (this->tag_suffix_ > 99)
+         {
+            this->tag_suffix_ = 0;
+            --this->tag_prefix_;
+         }
+      } while (this->used_hoi4_tags_.contains(possible_hoi4_tag));
+      this->country_mappings_.emplace(country.GetNumber(), possible_hoi4_tag);
+      this->used_hoi4_tags_.emplace(possible_hoi4_tag);
+      return true;
+   };
 
    // Attempt to name (or defer naming of) a country. Only the first successful strategy will be used.
-   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<StrategyFn>&& strategies)
+   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<CountryStrategyFn>&& strategies)
    {
-      static_cast<void>(std::any_of(strategies.begin(), strategies.end(), [country](StrategyFn fn) {
+      static_cast<void>(std::any_of(strategies.begin(), strategies.end(), [country](CountryStrategyFn fn) {
          return fn(country);
       }));
    }

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -1,5 +1,6 @@
 #include "src/mappers/country/country_mapper_creator.h"
 
+#include <execution>
 #include <queue>
 #include <ranges>
 
@@ -40,108 +41,137 @@ std::map<std::string, std::string> ImportMappingRules(std::string_view country_m
    return country_mapping_rules;
 }
 
+/// Class so that different mapping strategies can share global variables like country_mappings and
+/// country_mapping_rules
+class CountryMappingCreator
+{
+   std::map<int, std::string> country_mappings = {};
+   std::map<std::string, std::string> country_mapping_rules;
+   std::vector<const vic3::Country*> deferred_map_countries = {};
+
+   std::set<std::string> used_hoi4_tags = {};
+   char tag_prefix = 'Z';
+   int tag_suffix = 0;
+
+   // note: these are static because of bound function weirdness
+
+   // Rebel countries should be deferred to give priority to non-rebel countries.
+   static bool DeferCountryWithCivilWar(CountryMappingCreator* this_, const vic3::Country& country)
+   {
+      if (country.IsCivilWarCountry())
+      {
+         this_->deferred_map_countries.push_back(&country);
+         return true;
+      }
+      return false;
+   }
+
+   // decltype this because function types are a pain to write out
+   using CountryStrategyFn = decltype(DeferCountryWithCivilWar);
+
+   // Countries with an existing rule should be converted.
+   static bool AddCountryWithRule(CountryMappingCreator* this_, const vic3::Country& country)
+   {
+      const auto& vic3_tag = country.GetTag();
+      const auto& mappingRule = this_->country_mapping_rules.find(vic3_tag);
+      if (mappingRule != this_->country_mapping_rules.end() &&
+          this_->used_hoi4_tags.emplace(mappingRule->second).second)
+      {
+         this_->country_mappings.emplace(country.GetNumber(), mappingRule->second);
+         return true;
+      }
+      return false;
+   }
+
+   // Countries should always be deferred.
+   static bool DeferCountryAlways(CountryMappingCreator* this_, const vic3::Country& country)
+   {
+      this_->deferred_map_countries.push_back(&country);
+      return true;
+   }
+
+   // Countries should be added via their vic3 tag.
+   static bool AddCountryWithVicId(CountryMappingCreator* this_, const vic3::Country& country)
+   {
+      const auto vic3_tag = country.GetTag();
+      if (vic3_tag.length() == 3 && this_->used_hoi4_tags.emplace(vic3_tag).second)
+      {
+         this_->country_mappings.emplace(country.GetNumber(), vic3_tag);
+         return true;
+      }
+      return false;
+   }
+
+   // Countries should be added with Znn naming scheme. This always succeeds.
+   static bool AddCountryWithZ(CountryMappingCreator* this_, const vic3::Country& country)
+   {
+      std::string possible_hoi4_tag;
+      do
+      {
+         possible_hoi4_tag = fmt::format("{}{:0>2}", this_->tag_prefix, this_->tag_suffix);
+         ++this_->tag_suffix;
+         if (this_->tag_suffix > 99)
+         {
+            this_->tag_suffix = 0;
+            --this_->tag_prefix;
+         }
+      } while (this_->used_hoi4_tags.contains(possible_hoi4_tag));
+      this_->country_mappings.emplace(country.GetNumber(), possible_hoi4_tag);
+      this_->used_hoi4_tags.emplace(possible_hoi4_tag);
+      return true;
+   }
+
+   // Attempt to name (or defer naming of) a country. Only the first successful strategy will be used.
+   void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<CountryStrategyFn*> strategies)
+   {
+      for (decltype(strategies)::const_iterator strategy = strategies.begin(); strategy != strategies.end(); ++strategy)
+      {
+         if ((**strategy)(this,country))
+         {
+            return;
+         }
+      }
+   }
+
+  public:
+   CountryMappingCreator(std::string_view country_mappings_file):
+       country_mapping_rules(ImportMappingRules(country_mappings_file))
+   {
+   }
+
+   // Where the logic happens
+   std::map<int, std::string>&& AssignTags(auto countries)
+   {
+      for (const auto& country: countries)
+      {
+         ExecuteStrategiesForCountry(country, {DeferCountryWithCivilWar, AddCountryWithRule, DeferCountryAlways});
+      }
+
+      // after we got the initial rule countries, try again via vicId and then Znn
+      std::vector<const vic3::Country*> currentDeferredCountries = std::move(deferred_map_countries);
+      deferred_map_countries = {};
+      for (const auto& country: currentDeferredCountries)
+      {
+         ExecuteStrategiesForCountry(*country, {DeferCountryWithCivilWar, AddCountryWithVicId, AddCountryWithZ});
+      }
+      // finally try the civil war countries
+      currentDeferredCountries = std::move(deferred_map_countries);
+      deferred_map_countries = {};
+      for (const auto& country: currentDeferredCountries)
+      {
+         ExecuteStrategiesForCountry(*country, {AddCountryWithRule, AddCountryWithVicId, AddCountryWithZ});
+      }
+
+      return std::move(country_mappings);
+   }
+};
+
 }  // namespace
 
 
 mappers::CountryMapper mappers::CreateCountryMappings(std::string_view country_mappings_file,
     const std::map<int, vic3::Country>& countries)
 {
-   std::map<int, std::string> country_mappings;
-
-   // vic3 tag -> hoi4 tag
-   std::map<std::string, std::string> country_mapping_rules = ImportMappingRules(country_mappings_file);
-   char tag_prefix = 'Z';
-   int tag_suffix = 0;
-
-   std::vector<const vic3::Country*> deferred_map_countries = {};
-   // civil war countries are very last.
-   std::vector<const vic3::Country*> civilwar_map_countries = {};
-
-   std::set<std::string> used_hoi4_tags;
-   for (const vic3::Country& country: countries | std::views::values)
-   {
-      const auto& vic3_tag = country.GetTag();
-      const auto& mappingRule = country_mapping_rules.find(vic3_tag);
-      if (!country.IsCivilWarCountry() && mappingRule != country_mapping_rules.end() &&
-          used_hoi4_tags.emplace(mappingRule->second).second)
-      {
-         country_mappings.emplace(country.GetNumber(), mappingRule->second);
-      }
-      else if (!country.IsCivilWarCountry())
-      {
-         deferred_map_countries.emplace_back(&country);
-      }
-      else
-      {
-         civilwar_map_countries.emplace_back(&country);
-      }
-   }
-
-   for (const auto& country: deferred_map_countries)
-   {
-      const auto& vic3_tag = country->GetTag();
-      // first, attempt to map the default rule again. This will trigger for civil war countries
-      //  that have a different tag from their parent country.
-      const auto& mappingRule = country_mapping_rules.find(vic3_tag);
-      if (mappingRule != country_mapping_rules.end() && used_hoi4_tags.emplace(mappingRule->second).second)
-      {
-         country_mappings.emplace(country->GetNumber(), vic3_tag);
-      }
-      // if that doesn't work, try to use vic3 country tag next
-      else if (vic3_tag.length() == 3 && used_hoi4_tags.emplace(vic3_tag).second)
-      {
-         country_mappings.emplace(country->GetNumber(), vic3_tag);
-      }
-      else
-      {
-         std::string possible_hoi4_tag = fmt::format("{}{:0>2}", tag_prefix, tag_suffix);
-         while (used_hoi4_tags.contains(possible_hoi4_tag))
-         {
-            ++tag_suffix;
-            if (tag_suffix > 99)
-            {
-               tag_suffix = 0;
-               --tag_prefix;
-            }
-            possible_hoi4_tag = fmt::format("{}{:0>2}", tag_prefix, tag_suffix);
-         }
-         country_mappings.emplace(country->GetNumber(), possible_hoi4_tag);
-         used_hoi4_tags.emplace(possible_hoi4_tag);
-      }
-   }
-
-   for (const auto& country: civilwar_map_countries)
-   {
-      const auto& vic3_tag = country->GetTag();
-      // first, attempt to map the default rule again. This will trigger for civil war countries
-      //  that have a different tag from their parent country.
-      const auto& mappingRule = country_mapping_rules.find(vic3_tag);
-      if (mappingRule != country_mapping_rules.end() && used_hoi4_tags.emplace(mappingRule->second).second)
-      {
-         country_mappings.emplace(country->GetNumber(), vic3_tag);
-      }
-      // if that doesn't work, try to use vic3 country tag next
-      else if (vic3_tag.length() == 3 && used_hoi4_tags.emplace(vic3_tag).second)
-      {
-         country_mappings.emplace(country->GetNumber(), vic3_tag);
-      }
-      else
-      {
-         std::string possible_hoi4_tag = fmt::format("{}{:0>2}", tag_prefix, tag_suffix);
-         while (used_hoi4_tags.contains(possible_hoi4_tag))
-         {
-            ++tag_suffix;
-            if (tag_suffix > 99)
-            {
-               tag_suffix = 0;
-               --tag_prefix;
-            }
-            possible_hoi4_tag = fmt::format("{}{:0>2}", tag_prefix, tag_suffix);
-         }
-         country_mappings.emplace(country->GetNumber(), possible_hoi4_tag);
-         used_hoi4_tags.emplace(possible_hoi4_tag);
-      }
-   }
-
-   return CountryMapper(country_mappings);
+   CountryMappingCreator mappingCreator(country_mappings_file);
+   return CountryMapper(mappingCreator.AssignTags(countries | std::views::values));
 }

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -13,7 +13,7 @@
 namespace
 {
 
-std::map<std::string, std::string>&& ImportMappingRules(std::string_view country_mappings_file)
+std::map<std::string, std::string> ImportMappingRules(std::string_view country_mappings_file)
 {
    std::map<std::string, std::string> country_mapping_rules;  // vic3 tag -> hoi4 tag
 
@@ -38,7 +38,7 @@ std::map<std::string, std::string>&& ImportMappingRules(std::string_view country
 
    country_mappings_parser.parseFile(country_mappings_file);
 
-   return std::move(country_mapping_rules);
+   return country_mapping_rules;
 }
 
 /// Class so that different mapping strategies can share global variables like country_mappings and
@@ -46,7 +46,7 @@ std::map<std::string, std::string>&& ImportMappingRules(std::string_view country
 class CountryMappingCreator
 {
    std::map<int, std::string> country_mappings_ = {};
-   std::map<std::string, std::string> country_mapping_rules_;
+   std::map<std::string, std::string> country_mapping_rules_ = {};
    std::vector<const vic3::Country*> deferred_map_countries_ = {};
 
    std::set<std::string> used_hoi4_tags_ = {};

--- a/src/mappers/country/country_mapper_creator.cpp
+++ b/src/mappers/country/country_mapper_creator.cpp
@@ -52,7 +52,7 @@ class CountryMappingCreator
    std::set<std::string> used_hoi4_tags_ = {};
    char tag_prefix_ = 'Z';
    int tag_suffix_ = 0;
-  
+
    using CountryStrategyFn = std::function<bool(const vic3::Country&)>;
 
    // Rebel countries should be deferred to give priority to non-rebel countries.
@@ -116,7 +116,7 @@ class CountryMappingCreator
    // Attempt to name (or defer naming of) a country. Only the first successful strategy will be used.
    void ExecuteStrategiesForCountry(const vic3::Country& country, const std::vector<CountryStrategyFn>&& strategies)
    {
-      static_cast<void>(std::any_of(strategies.begin(), strategies.end(), [country](CountryStrategyFn fn) {
+      static_cast<void>(std::any_of(strategies.begin(), strategies.end(), [&country](CountryStrategyFn fn) {
          return fn(country);
       }));
    }
@@ -131,6 +131,7 @@ class CountryMappingCreator
    std::map<int, std::string>&& AssignTags(auto countries)
    {
       country_mappings_.clear();
+      deferred_map_countries_.clear();
       tag_prefix_ = 'Z';
       tag_suffix_ = 0;
 

--- a/src/mappers/country/country_mapper_creator_tests.cpp
+++ b/src/mappers/country/country_mapper_creator_tests.cpp
@@ -46,6 +46,32 @@ TEST(MappersCountryCountryMapperCreator, GeneratedMappingsDecrementTheAlphaWhenT
    EXPECT_EQ(country_mapper.GetHoiTag(101), "Y01");
 }
 
+TEST(MappersCountryCountryMapperCreator, SourceTagAsPrimaryFallback)
+{
+   const std::map<int, vic3::Country> source_countries{
+       {1, vic3::Country({.number = 1, .tag = "TAG"})},
+       {2, vic3::Country({.number = 2, .tag = "TWO"})},
+       {3, vic3::Country({.number = 3, .tag = "TWO"})},
+   };
+
+   const CountryMapper country_mapper = CreateCountryMappings("", source_countries);
+   EXPECT_EQ(country_mapper.GetHoiTag(1), "TAG");
+   EXPECT_EQ(country_mapper.GetHoiTag(2), "TWO");
+   EXPECT_EQ(country_mapper.GetHoiTag(3), "Z00");  // "TWO" was already taken, so fall back to the Znn system
+}
+
+TEST(MappersCountryCountryMapperCreator, CivilWarCountryIsSecondary)
+{
+   const std::map<int, vic3::Country> source_countries{
+       {1, vic3::Country({.number = 1, .tag = "TAG", .is_civil_war = true})},
+       {2, vic3::Country({.number = 2, .tag = "TAG"})},
+   };
+
+   const CountryMapper country_mapper = CreateCountryMappings("", source_countries);
+   EXPECT_EQ(country_mapper.GetHoiTag(1), "Z00");
+   EXPECT_EQ(country_mapper.GetHoiTag(2), "TAG");
+   
+}
 
 TEST(MappersCountryCountryMapperCreator, MappingsCanComeFromRulesFile)
 {
@@ -53,7 +79,7 @@ TEST(MappersCountryCountryMapperCreator, MappingsCanComeFromRulesFile)
        {1, vic3::Country({.number = 1, .tag = "TAG"})},
        {2, vic3::Country({.number = 2, .tag = "TWO"})},
        {3, vic3::Country({.number = 3, .tag = "THR"})},
-       {4, vic3::Country({.number = 4, .tag = "TWO"})},
+       {4, vic3::Country({.number = 4, .tag = "Z00"})},
    };
 
    const CountryMapper country_mapper = CreateCountryMappings(
@@ -64,5 +90,7 @@ TEST(MappersCountryCountryMapperCreator, MappingsCanComeFromRulesFile)
    EXPECT_EQ(country_mapper.GetHoiTag(3), "Z00");  // From rule.
    EXPECT_EQ(country_mapper.GetHoiTag(4), "Z01");  // Generated. Previous rule generated Z00, so advanced to Z01.
 }
+
+
 
 }  // namespace mappers

--- a/src/mappers/country/country_mapper_creator_tests.cpp
+++ b/src/mappers/country/country_mapper_creator_tests.cpp
@@ -70,7 +70,6 @@ TEST(MappersCountryCountryMapperCreator, CivilWarCountryIsSecondary)
    const CountryMapper country_mapper = CreateCountryMappings("", source_countries);
    EXPECT_EQ(country_mapper.GetHoiTag(1), "Z00");
    EXPECT_EQ(country_mapper.GetHoiTag(2), "TAG");
-   
 }
 
 TEST(MappersCountryCountryMapperCreator, MappingsCanComeFromRulesFile)

--- a/src/mappers/country/country_mapper_creator_tests.cpp
+++ b/src/mappers/country/country_mapper_creator_tests.cpp
@@ -90,6 +90,4 @@ TEST(MappersCountryCountryMapperCreator, MappingsCanComeFromRulesFile)
    EXPECT_EQ(country_mapper.GetHoiTag(4), "Z01");  // Generated. Previous rule generated Z00, so advanced to Z01.
 }
 
-
-
 }  // namespace mappers

--- a/src/vic3_world/countries/vic3_country.h
+++ b/src/vic3_world/countries/vic3_country.h
@@ -20,6 +20,7 @@ struct CountryOptions
    commonItems::Color color;
    std::optional<int> capital_state;
    std::string country_type;
+   bool is_civil_war;
    std::set<std::string> active_laws;
    std::set<int> primary_culture_ids;
    std::set<std::string> primary_cultures;
@@ -40,6 +41,7 @@ class Country
        color_(options.color),
        capital_state_(options.capital_state),
        country_type_(std::move(options.country_type)),
+       is_civil_war_(options.is_civil_war),
        active_laws_(std::move(options.active_laws)),
        primary_cultures_(std::move(options.primary_cultures)),
        primary_culture_ids_(std::move(options.primary_culture_ids)),
@@ -56,6 +58,8 @@ class Country
    [[nodiscard]] const commonItems::Color& GetColor() const { return color_; }
    [[nodiscard]] const std::optional<int>& GetCapitalState() const { return capital_state_; }
    [[nodiscard]] bool IsDecentralized() const { return country_type_ == "decentralized"; }
+   // are these rebels
+   [[nodiscard]] bool IsCivilWarCountry() const { return is_civil_war_; }
    [[nodiscard]] const std::set<std::string>& GetActiveLaws() const { return active_laws_; }
    [[nodiscard]] const std::set<std::string>& GetPrimaryCultures() const { return primary_cultures_; }
    [[nodiscard]] const std::set<int>& GetPrimaryCultureIds() const { return primary_culture_ids_; }
@@ -82,6 +86,7 @@ class Country
    commonItems::Color color_;
    std::optional<int> capital_state_;
    std::string country_type_;
+   bool is_civil_war_;
    std::set<std::string> active_laws_;
    std::set<std::string> primary_cultures_;
    std::set<int> primary_culture_ids_;  // Resolve to culture name before HoI

--- a/src/vic3_world/countries/vic3_country_importer.cpp
+++ b/src/vic3_world/countries/vic3_country_importer.cpp
@@ -17,6 +17,9 @@ vic3::CountryImporter::CountryImporter()
    country_parser_.registerKeyword("country_type", [this](std::istream& input_stream) {
       country_type_ = commonItems::getString(input_stream);
    });
+   country_parser_.registerKeyword("civil_war", [this](std::istream& input_stream) {
+      is_civil_war_ = commonItems::getString(input_stream) == "yes";
+   });
    country_parser_.registerKeyword("cultures", [this](std::istream& input_stream) {
       for (const auto& culture_id: commonItems::getInts(input_stream))
       {
@@ -61,6 +64,7 @@ std::optional<vic3::Country> vic3::CountryImporter::ImportCountry(const int numb
        .color = color,
        .capital_state = capital_,
        .country_type = country_type_,
+       .is_civil_war = is_civil_war_,
        .primary_culture_ids = primary_culture_ids_,
        .head_of_state_id = head_of_state_id_});
 }

--- a/src/vic3_world/countries/vic3_country_importer.h
+++ b/src/vic3_world/countries/vic3_country_importer.h
@@ -29,6 +29,7 @@ class CountryImporter
    std::string tag_;
    std::optional<int> capital_;
    std::string country_type_;
+   bool is_civil_war_ = false;
    std::set<int> primary_culture_ids_;
    int head_of_state_id_;
 

--- a/src/vic3_world/countries/vic3_country_importer_tests.cpp
+++ b/src/vic3_world/countries/vic3_country_importer_tests.cpp
@@ -34,6 +34,7 @@ TEST(Vic3WorldCountriesCountryImporter, DefaultsAreDefaulted)
    EXPECT_TRUE(country->GetPrimaryCultureIds().empty());
    EXPECT_EQ(country->GetLastElection(), std::nullopt);
    EXPECT_EQ(country->GetHeadOfStateId(), 0);
+   EXPECT_FALSE(country->IsCivilWarCountry());
 }
 
 
@@ -90,6 +91,22 @@ TEST(Vic3WorldCountriesCountryImporter, MultipleCountriesCanBeImported)
    EXPECT_EQ(country_two->GetCapitalState(), std::nullopt);
 }
 
+TEST(Vic3WorldCountriesCountryImporter, CivilWarDetected)
+{
+   CountryImporter country_importer;
+
+   std::stringstream input_one;
+   input_one << "={\n";
+   input_one << "\tdefinition=\"TAG\"";
+   input_one << "\tcivil_war=\"yes\"";
+   input_one << "\tcapital=12345\n";
+   input_one << "}";
+   const auto country_one =
+       country_importer.ImportCountry(144, input_one, {{"TAG", commonItems::Color(std::array{1, 2, 3})}});
+
+   ASSERT_TRUE(country_one.has_value());
+   EXPECT_TRUE(country_one->IsCivilWarCountry());
+}
 
 TEST(Vic3WorldCountriesCountryImporter, ActiveLawsCanBeSet)
 {


### PR DESCRIPTION
Assign tags in 3 phases:
1) non-civil war countries that have been mapped in the map file
2) non-civil war countries that have not been mapped
3) civil war countries 

Additionally, attempt to use vicky3 tag as hoi tag if it is available, before falling back to Z00-style tags.