### PR TITLE
Stub navy output.

### DIFF
--- a/src/out_hoi4/countries/out_countries.cpp
+++ b/src/out_hoi4/countries/out_countries.cpp
@@ -30,6 +30,7 @@ void out::OutputCountries(std::string_view output_name,
       auto oob_file = fmt::format("output/{}/history/units/{}_1936.txt", output_name, tag);
       commonItems::TryCopyFile("configurables/division_templates.txt", oob_file);
       OutputCountryUnits(oob_file, country);
+      OutputCountryNavy(output_name, country);
       OutputFocusTree(output_name, tag);
    }
 

--- a/src/out_hoi4/countries/out_countries_tests.cpp
+++ b/src/out_hoi4/countries/out_countries_tests.cpp
@@ -210,4 +210,53 @@ TEST(Outhoi4CountriesOutcountriesTests, NationalFocusFilesAreCreated)
    country_file_two.close();
 }
 
+
+TEST(Outhoi4CountriesOutcountriesTests, NavyFilesAreCreated)
+{
+   CreateFolders("NavyFilesAreCreated");
+
+   OutputCountries("NavyFilesAreCreated",
+       {
+           {"TAG", hoi4::Country({.tag = "TAG"})},
+           {"TWO", hoi4::Country({.tag = "TWO"})},
+       },
+       {});
+
+   EXPECT_TRUE(commonItems::DoesFileExist("output/NavyFilesAreCreated/history/units/TAG_1936_Naval.txt"));
+   std::ifstream country_file_one("output/NavyFilesAreCreated/history/units/TAG_1936_Naval.txt");
+   ASSERT_TRUE(country_file_one.is_open());
+   std::stringstream country_file_one_stream;
+   std::copy(std::istreambuf_iterator<char>(country_file_one),
+       std::istreambuf_iterator<char>(),
+       std::ostreambuf_iterator<char>(country_file_one_stream));
+   country_file_one.close();
+
+   EXPECT_TRUE(commonItems::DoesFileExist("output/NavyFilesAreCreated/history/units/TAG_1936_Naval_Legacy.txt"));
+   std::ifstream legacy_file_one("output/NavyFilesAreCreated/history/units/TAG_1936_Naval_Legacy.txt");
+   ASSERT_TRUE(legacy_file_one.is_open());
+   std::stringstream legacy_file_one_stream;
+   std::copy(std::istreambuf_iterator<char>(legacy_file_one),
+       std::istreambuf_iterator<char>(),
+       std::ostreambuf_iterator<char>(legacy_file_one_stream));
+   legacy_file_one.close();
+
+   EXPECT_TRUE(commonItems::DoesFileExist("output/NavyFilesAreCreated/history/units/TWO_1936_Naval.txt"));
+   std::ifstream country_file_two("output/NavyFilesAreCreated/history/units/TWO_1936_Naval.txt");
+   ASSERT_TRUE(country_file_two.is_open());
+   std::stringstream country_file_two_stream;
+   std::copy(std::istreambuf_iterator<char>(country_file_two),
+       std::istreambuf_iterator<char>(),
+       std::ostreambuf_iterator<char>(country_file_two_stream));
+   country_file_two.close();
+
+   EXPECT_TRUE(commonItems::DoesFileExist("output/NavyFilesAreCreated/history/units/TWO_1936_Naval_Legacy.txt"));
+   std::ifstream legacy_file_two("output/NavyFilesAreCreated/history/units/TWO_1936_Naval_Legacy.txt");
+   ASSERT_TRUE(legacy_file_two.is_open());
+   std::stringstream legacy_file_two_stream;
+   std::copy(std::istreambuf_iterator<char>(legacy_file_two),
+       std::istreambuf_iterator<char>(),
+       std::ostreambuf_iterator<char>(legacy_file_two_stream));
+   legacy_file_two.close();
+}
+
 }  // namespace out

--- a/src/out_hoi4/countries/out_country.cpp
+++ b/src/out_hoi4/countries/out_country.cpp
@@ -217,6 +217,7 @@ void out::OutputCountryHistory(std::string_view output_name,
 
    country_history << "if = {\n";
    country_history << "\tlimit = { not = { has_dlc = \"Man the Guns\" } }\n";
+   country_history << fmt::format("\tset_naval_oob = {}_1936_Naval_Legacy\n", tag);
    for (const auto& variant: country.GetLegacyShipVariants())
    {
       country_history << variant;
@@ -224,6 +225,7 @@ void out::OutputCountryHistory(std::string_view output_name,
    country_history << "}\n";
    country_history << "if = {\n";
    country_history << "\tlimit = { has_dlc = \"Man the Guns\" }\n";
+   country_history << fmt::format("\tset_naval_oob = {}_1936_Naval\n", tag);
    for (const auto& variant: country.GetShipVariants())
    {
       country_history << variant;
@@ -246,6 +248,29 @@ void out::OutputCountryHistory(std::string_view output_name,
 
    country_history.close();
 }
+
+
+void out::OutputCountryNavy(std::string_view output_name, const hoi4::Country& country)
+{
+   const std::string& tag = country.GetTag();
+   const auto naval_file_name = fmt::format("output/{}/history/units/{}_1936_Naval.txt", output_name, tag);
+   std::ofstream navy(naval_file_name);
+   if (!navy.is_open())
+   {
+      throw std::runtime_error(fmt::format("Could not create {}", naval_file_name));
+   }
+   const auto legacy_file_name = fmt::format("output/{}/history/units/{}_1936_Naval_Legacy.txt", output_name, tag);
+   std::ofstream legacy(legacy_file_name);
+   if (!legacy.is_open())
+   {
+      throw std::runtime_error(fmt::format("Could not create {}", legacy_file_name));
+   }
+   navy << "# Dummy file\n";
+   legacy << "# Dummy file\n";
+   navy.close();
+   legacy.close();
+}
+
 
 void out::OutputCountryUnits(const std::string& oob_file, const hoi4::Country& country)
 {

--- a/src/out_hoi4/countries/out_country.h
+++ b/src/out_hoi4/countries/out_country.h
@@ -25,7 +25,11 @@ void OutputCountryHistory(std::string_view output_name,
     const hoi4::Country& country,
     const std::map<int, hoi4::Character>& characters);
 
+void OutputCountryNavy(std::string_view output_name, const hoi4::Country& country);
+
 void OutputCountryUnits(const std::string& oob_file, const hoi4::Country& country);
+
+
 
 }  // namespace out
 

--- a/src/out_hoi4/countries/out_country_tests.cpp
+++ b/src/out_hoi4/countries/out_country_tests.cpp
@@ -298,9 +298,11 @@ TEST(Outhoi4CountriesOutcountryTests, DefaultsAreSetInCountryHistoryFile)
    expected_one << "# Starting tech\n";
    expected_one << "if = {\n";
    expected_one << "\tlimit = { not = { has_dlc = \"Man the Guns\" } }\n";
+   expected_one << "\tset_naval_oob = TAG_1936_Naval_Legacy\n";
    expected_one << "}\n";
    expected_one << "if = {\n";
    expected_one << "\tlimit = { has_dlc = \"Man the Guns\" }\n";
+   expected_one << "\tset_naval_oob = TAG_1936_Naval\n";
    expected_one << "}\n";
    expected_one << "if = {\n";
    expected_one << "\tlimit = { has_dlc = \"By Blood Alone\" }\n";
@@ -410,9 +412,11 @@ TEST(Outhoi4CountriesOutcountryTests, IdeasAreOutputToCountryHistoryFile)
    expected_one << "# Starting tech\n";
    expected_one << "if = {\n";
    expected_one << "\tlimit = { not = { has_dlc = \"Man the Guns\" } }\n";
+   expected_one << "\tset_naval_oob = TAG_1936_Naval_Legacy\n";
    expected_one << "}\n";
    expected_one << "if = {\n";
    expected_one << "\tlimit = { has_dlc = \"Man the Guns\" }\n";
+   expected_one << "\tset_naval_oob = TAG_1936_Naval\n";
    expected_one << "}\n";
    expected_one << "if = {\n";
    expected_one << "\tlimit = { has_dlc = \"By Blood Alone\" }\n";
@@ -598,6 +602,7 @@ TEST(Outhoi4CountriesOutcountryTests, EquipmentVariantsAreOutput)
    const std::string expected_output =
        "if = {\n"
        "\tlimit = { not = { has_dlc = \"Man the Guns\" } }\n"
+       "\tset_naval_oob = TAG_1936_Naval_Legacy\n"
        "\tcreate_equipment_variant = {\n"
        "\t\tname = legacy_ship: variant_one\n"
        "\t}\n"
@@ -607,6 +612,7 @@ TEST(Outhoi4CountriesOutcountryTests, EquipmentVariantsAreOutput)
        "}\n"
        "if = {\n"
        "\tlimit = { has_dlc = \"Man the Guns\" }\n"
+       "\tset_naval_oob = TAG_1936_Naval\n"
        "\tcreate_equipment_variant = {\n"
        "\t\tname = ship: variant_one\n"
        "\t}\n"
@@ -756,6 +762,41 @@ TEST(Outhoi4CountriesOutcountryTests, UnitsAreOutputToCountryOOBFile)
        "}\n";
 
    EXPECT_THAT(country_file_stream.str(), testing::HasSubstr(expected));
+}
+
+TEST(Outhoi4CountriesOutcountryTests, NaviesAreOutputToCountryNavalFiles)
+{
+   commonItems::TryCreateFolder("output");
+   commonItems::TryCreateFolder("output/NaviesAreOutputToCountryNavalFiles");
+   commonItems::TryCreateFolder("output/NaviesAreOutputToCountryNavalFiles/history");
+   commonItems::TryCreateFolder("output/NaviesAreOutputToCountryNavalFiles/history/units");
+
+   const hoi4::Country country({.tag = "TAG"});
+   OutputCountryNavy("NaviesAreOutputToCountryNavalFiles", country);
+
+   const std::string naval_file = "output/NaviesAreOutputToCountryNavalFiles/history/units/TAG_1936_Naval.txt";
+   ASSERT_TRUE(commonItems::DoesFileExist(naval_file));
+   std::ifstream navy(naval_file);
+   ASSERT_TRUE(navy.is_open());
+   std::stringstream navy_stream;
+   std::copy(std::istreambuf_iterator<char>(navy),
+       std::istreambuf_iterator<char>(),
+       std::ostreambuf_iterator<char>(navy_stream));
+   navy.close();
+   const char* expected_navy = "Dummy file";
+   EXPECT_THAT(navy_stream.str(), testing::HasSubstr(expected_navy));
+
+   const std::string legacy_file = "output/NaviesAreOutputToCountryNavalFiles/history/units/TAG_1936_Naval_Legacy.txt";
+   ASSERT_TRUE(commonItems::DoesFileExist(legacy_file));
+   std::ifstream legacy(legacy_file);
+   ASSERT_TRUE(legacy.is_open());
+   std::stringstream legacy_stream;
+   std::copy(std::istreambuf_iterator<char>(legacy),
+       std::istreambuf_iterator<char>(),
+       std::ostreambuf_iterator<char>(legacy_stream));
+   legacy.close();
+   const char* expected_legacy = "Dummy file";
+   EXPECT_THAT(legacy_stream.str(), testing::HasSubstr(expected_legacy));
 }
 
 


### PR DESCRIPTION
Adds dummy files for navy OOBs. This doesn't have any user-visible effect but will be part of naval conversion, and stands alone.