### PR TITLE
Cleanup Vic 1.5 character changes

### DIFF
--- a/data/test_files/vic3_world/world/test_save.vic3
+++ b/data/test_files/vic3_world/world/test_save.vic3
@@ -179,6 +179,7 @@ last_name=Mande
 culture=0
 role=general
 rank="commander_rank_2"
+formation = 1234
 }
 3=none
 4={
@@ -194,6 +195,7 @@ culture=1
 role=politician
 role=general
 rank="commander_rank_ruler"
+formation = 1234
 }
 6={
 first_name=Martin

--- a/src/vic3_world/characters/vic3_character.h
+++ b/src/vic3_world/characters/vic3_character.h
@@ -24,7 +24,7 @@ struct CharacterOptions
    std::set<std::string> traits;
    std::string origin_tag;
    std::optional<int> origin_country_id;
-   bool is_commander = false;
+   std::optional<int> formation_id;
 };
 
 class Character
@@ -44,7 +44,7 @@ class Character
        traits_(std::move(options.traits)),
        origin_tag_(std::move(options.origin_tag)),
        origin_country_id_(options.origin_country_id),
-       is_commander_(options.is_commander)
+       formation_id_(options.formation_id)
    {
    }
 
@@ -62,14 +62,13 @@ class Character
    [[nodiscard]] const std::set<std::string>& GetTraits() const { return traits_; }
    [[nodiscard]] const std::string& GetOriginTag() const { return origin_tag_; }
    [[nodiscard]] const std::optional<int>& GetOriginCountryId() const { return origin_country_id_; }
-   [[nodiscard]] bool IsCommander() const { return is_commander_; }
+   [[nodiscard]] bool IsCommander() const { return formation_id_.has_value(); }
 
 
    void SetCulture(std::string culture) { culture_ = std::move(culture); }
    void SetHomeTag(std::string tag) { origin_tag_ = std::move(tag); }
    void SetOriginCountryId(int id) { origin_country_id_ = id; }
    void SetIgId(const int id) { ig_id_ = id; }
-   void SetCommander() { is_commander_ = true; }
 
    std::partial_ordering operator<=>(const Character&) const = default;
 
@@ -88,7 +87,7 @@ class Character
    std::set<std::string> traits_;
    std::string origin_tag_;  // Where an agitator was exiled from, resolve to ID before HoI
    std::optional<int> origin_country_id_;
-   bool is_commander_ = false;  // Actively hired to lead boats/troops
+   std::optional<int> formation_id_;  // Commanders with formations are actively hired to lead boats/troops
 };
 }  // namespace vic3
 

--- a/src/vic3_world/characters/vic3_character.h
+++ b/src/vic3_world/characters/vic3_character.h
@@ -69,6 +69,7 @@ class Character
    void SetHomeTag(std::string tag) { origin_tag_ = std::move(tag); }
    void SetOriginCountryId(int id) { origin_country_id_ = id; }
    void SetIgId(const int id) { ig_id_ = id; }
+   void SetCommander() { formation_id_ = 0; }  // For backwards compatibility with pre 1.5 Vic
 
    std::partial_ordering operator<=>(const Character&) const = default;
 

--- a/src/vic3_world/characters/vic3_character_importer.cpp
+++ b/src/vic3_world/characters/vic3_character_importer.cpp
@@ -37,6 +37,9 @@ vic3::CharacterImporter::CharacterImporter()
          Log(LogLevel::Warning) << fmt::format("Failed to read rank: {}. {}", rank_string, e.what());
       }
    });
+   character_parser_.registerKeyword("formation", [this](std::istream& input_stream) {
+      formation_id_ = commonItems::getInt(input_stream);
+   });
    character_parser_.registerKeyword("ideology", [this](std::istream& input_stream) {
       ideology_ = commonItems::getString(input_stream);
    });
@@ -58,6 +61,7 @@ vic3::Character vic3::CharacterImporter::ImportCharacter(const int id, std::istr
    rank_ = 0;
    ideology_.clear();
    traits_.clear();
+   formation_id_.reset();
 
    character_parser_.parseStream(input_stream);
 
@@ -69,5 +73,6 @@ vic3::Character vic3::CharacterImporter::ImportCharacter(const int id, std::istr
        .roles = roles_,
        .rank = rank_,
        .ideology = ideology_,
-       .traits = traits_});
+       .traits = traits_,
+   .formation_id = formation_id_});
 }

--- a/src/vic3_world/characters/vic3_character_importer.cpp
+++ b/src/vic3_world/characters/vic3_character_importer.cpp
@@ -74,5 +74,5 @@ vic3::Character vic3::CharacterImporter::ImportCharacter(const int id, std::istr
        .rank = rank_,
        .ideology = ideology_,
        .traits = traits_,
-   .formation_id = formation_id_});
+       .formation_id = formation_id_});
 }

--- a/src/vic3_world/characters/vic3_character_importer.h
+++ b/src/vic3_world/characters/vic3_character_importer.h
@@ -30,6 +30,7 @@ class CharacterImporter
    int rank_ = 0;
    std::string ideology_;
    std::set<std::string> traits_;
+   std::optional<int> formation_id_;
 };
 
 }  // namespace vic3

--- a/src/vic3_world/characters/vic3_character_importer_tests.cpp
+++ b/src/vic3_world/characters/vic3_character_importer_tests.cpp
@@ -29,7 +29,7 @@ TEST(Vic3worldCharactersVic3characterimporter, DefaultsDefaultToDefault)
            .traits = std::set<std::string>{},
            .origin_tag = "",
            .origin_country_id = std::nullopt,
-       .formation_id = std::nullopt}));
+           .formation_id = std::nullopt}));
 }
 
 
@@ -63,7 +63,7 @@ TEST(Vic3worldCharactersVic3characterimporter, CharacterCanBeImported)
            .rank = 5,
            .ideology = "ideology_0",
            .traits = {"trait_0", "trait_1"},
-       .formation_id = 238}));
+           .formation_id = 238}));
 }
 
 
@@ -140,6 +140,19 @@ TEST(Vic3worldCharactersVic3characterimporter, IgIdCanBeSet)
    character.SetIgId(1);
 
    EXPECT_EQ(character, Character({.id = 1, .ig_id = 1}));
+}
+
+
+TEST(Vic3worldCharactersVic3characterimporter, CommanderCanBeSet)
+{
+   CharacterImporter character_importer;
+
+   std::stringstream input;
+   auto character = character_importer.ImportCharacter(1, input);
+
+   character.SetCommander();
+
+   EXPECT_EQ(character, Character({.id = 1, .formation_id = 0}));
 }
 
 

--- a/src/vic3_world/characters/vic3_character_importer_tests.cpp
+++ b/src/vic3_world/characters/vic3_character_importer_tests.cpp
@@ -28,7 +28,8 @@ TEST(Vic3worldCharactersVic3characterimporter, DefaultsDefaultToDefault)
            .ideology = "",
            .traits = std::set<std::string>{},
            .origin_tag = "",
-           .origin_country_id = std::nullopt}));
+           .origin_country_id = std::nullopt,
+       .formation_id = std::nullopt}));
 }
 
 
@@ -47,6 +48,7 @@ TEST(Vic3worldCharactersVic3characterimporter, CharacterCanBeImported)
    input << "\tideology = \"ideology_0\"\n";
    input << "\trank = commander_rank_5\n";
    input << "\ttraits = { \"trait_0\" \"trait_1\" }\n";
+   input << "\tformation = 238\n";
    input << "}\n";
 
    const auto character = character_importer.ImportCharacter(1, input);
@@ -60,7 +62,8 @@ TEST(Vic3worldCharactersVic3characterimporter, CharacterCanBeImported)
            .roles = {"politician", "agitator"},
            .rank = 5,
            .ideology = "ideology_0",
-           .traits = {"trait_0", "trait_1"}}));
+           .traits = {"trait_0", "trait_1"},
+       .formation_id = 238}));
 }
 
 

--- a/src/vic3_world/characters/vic3_character_manager.cpp
+++ b/src/vic3_world/characters/vic3_character_manager.cpp
@@ -58,20 +58,30 @@ std::set<int> ImportExilePool(std::istream& input_stream)
    Log(LogLevel::Info) << fmt::format("\tFound {} homeless agitators.", exile_pool.size());
    return exile_pool;
 }
-std::set<int> ImportEmployedCommanders(std::istream& input_stream)
+int ImportObituary(std::istream& input_stream)
 {
-   std::set<int> hired_commanders;
+    int obituary = 0;
    commonItems::parser map_parser;
-   map_parser.registerRegex(commonItems::integerRegex,
-       [&hired_commanders](const std::string& hq_number_string, std::istream& input_stream) {
-          std::ranges::copy(commonItems::getInts(input_stream),
-              std::inserter(hired_commanders, hired_commanders.begin()));
+   map_parser.registerKeyword("object",
+       [&obituary](std::istream& input_stream) {
+           obituary = commonItems::getInt(input_stream);
        });
    map_parser.IgnoreUnregisteredItems();
    map_parser.parseStream(input_stream);
 
-   Log(LogLevel::Info) << fmt::format("\tFound {} employed commanders.", hired_commanders.size());
-   return hired_commanders;
+   return obituary;
+}
+std::set<int> ImportObituaries(std::istream& input_stream)
+{
+    std::set<int> obituaries;
+    const auto& blobs = commonItems::blobList(input_stream);
+    for (const std::string& blob : blobs.getBlobs())
+    {
+        auto obit_stream = std::stringstream(blob);
+        obituaries.insert(ImportObituary(obit_stream));
+    }
+   Log(LogLevel::Info) << fmt::format("\tFound {} dead characters. Hiding the bodies.", obituaries.size());
+    return obituaries;
 }
 }  // namespace
 
@@ -89,8 +99,14 @@ vic3::CharacterManager::CharacterManager(std::istream& input_stream)
    character_manager_parser_.registerKeyword("character_ig_map", [this](std::istream& input_stream) {
       character_ig_map_ = ImportCharacterIgMap(input_stream);
    });
-   character_manager_parser_.registerKeyword("home_hq_character_map", [this](std::istream& input_stream) {
-      hired_commanders_ = ImportEmployedCommanders(input_stream);
+   character_manager_parser_.registerKeyword("dead_objects", [this](std::istream& input_stream) {
+       commonItems::parser dead_parser;
+       dead_parser.registerKeyword("dead_objects",
+           [this](std::istream& input_stream) {
+               obituaries_ = ImportObituaries(input_stream);
+           });
+       dead_parser.IgnoreUnregisteredItems();
+       dead_parser.parseStream(input_stream);
    });
    character_manager_parser_.registerKeyword("exile_pool", [this](std::istream& input_stream) {
       exile_pool_ = ImportExilePool(input_stream);
@@ -100,7 +116,6 @@ vic3::CharacterManager::CharacterManager(std::istream& input_stream)
 
    AssignHomeTagToExiles();
    AssignIgToCharacters();
-   HireCommanders();
 }
 
 void vic3::CharacterManager::AssignHomeTagToExiles()
@@ -127,6 +142,11 @@ void vic3::CharacterManager::AssignIgToCharacters()
          continue;
       }
 
+      if (obituaries_.contains(character.GetId()))
+      {
+          continue;
+      }
+
       if (const auto itr = character_ig_map_.find(character.GetId()); itr != character_ig_map_.end())
       {
          character.SetIgId(itr->second);
@@ -137,17 +157,6 @@ void vic3::CharacterManager::AssignIgToCharacters()
              character.GetFirstName(),
              character.GetLastName(),
              character.GetId());
-      }
-   }
-}
-
-void vic3::CharacterManager::HireCommanders()
-{
-   for (auto& character: characters_ | std::views::values)
-   {
-      if (hired_commanders_.contains(character.GetId()))
-      {
-         character.SetCommander();
       }
    }
 }

--- a/src/vic3_world/characters/vic3_character_manager.h
+++ b/src/vic3_world/characters/vic3_character_manager.h
@@ -25,6 +25,7 @@ class CharacterManager
   private:
    void AssignHomeTagToExiles();
    void AssignIgToCharacters();
+   void HireCommanders();
 
    commonItems::parser character_manager_parser_;
 
@@ -33,6 +34,7 @@ class CharacterManager
    std::map<int, std::string> exile_origin_map_;
    std::map<int, int> character_ig_map_;
    std::set<int> exile_pool_;
+   std::set<int> hired_commanders_;
    std::set<int> obituaries_;
 };
 

--- a/src/vic3_world/characters/vic3_character_manager.h
+++ b/src/vic3_world/characters/vic3_character_manager.h
@@ -25,7 +25,6 @@ class CharacterManager
   private:
    void AssignHomeTagToExiles();
    void AssignIgToCharacters();
-   void HireCommanders();
 
    commonItems::parser character_manager_parser_;
 
@@ -34,7 +33,7 @@ class CharacterManager
    std::map<int, std::string> exile_origin_map_;
    std::map<int, int> character_ig_map_;
    std::set<int> exile_pool_;
-   std::set<int> hired_commanders_;
+   std::set<int> obituaries_;
 };
 
 }  // namespace vic3

--- a/src/vic3_world/characters/vic3_character_manager_tests.cpp
+++ b/src/vic3_world/characters/vic3_character_manager_tests.cpp
@@ -43,6 +43,7 @@ TEST(Vic3WorldCharactersVic3CharacterManagerImporter, CharactersCanBeImported)
    input << "ideology = \"ideology_1\"\n";
    input << "rank = commander_rank_2\n";
    input << "traits = { \"trait_2\" \"trait_3\" }\n";
+   input << "formation = 238\n";
    input << "}\n";
    input << "}\n";
    input << "}\n";
@@ -67,7 +68,8 @@ TEST(Vic3WorldCharactersVic3CharacterManagerImporter, CharactersCanBeImported)
                    .roles = {"general"},
                    .rank = 2,
                    .ideology = "ideology_1",
-                   .traits = {"trait_2", "trait_3"}}))));
+                   .traits = {"trait_2", "trait_3"},
+               .formation_id = 238}))));
 }
 
 
@@ -112,37 +114,32 @@ TEST(Vic3WorldCharactersVic3CharacterManagerImporter, IgsAreAssigned)
            testing::Pair(3, Character({.id = 3, .ig_id = 2}))));
 }
 
-
-TEST(Vic3WorldCharactersVic3CharacterManagerImporter, EmployedCommandersAreMarked)
+TEST(Vic3WorldCharactersVic3CharacterManagerImporter, TheDeadAreLogged)
 {
-   std::stringstream input;
-   input << "={\n";
-   input << "database={\n";
-   input << "1 = {\n";
-   input << "role = general\n";
+    std::stringstream input;
+    input << "={\n";
+    input << "database={\n";
+    input << "1 = {\n";
+    input << "}\n";
+    input << "3 ={ \n";
+    input << "}\n";
+    input << "}\n";
+    input << "dead_objects={\n";
+    input << "dead_objects={\n";
+    input << "{ object = 3 \ndeath_date = 1899.12.15 }\n"; 
+    input << "{ object = 1 \ndeath_date = 1869.12.17 }\n"; 
    input << "}\n";
-   input << "3 ={ \n";
-   input << "role = general\n";
-   input << "}\n";
-   input << "4 = {\n";
-   input << "role = admiral\n";
-   input << "}\n";
-   input << "6 ={ \n";
-   input << "role = admiral\n";
-   input << "}\n";
-   input << "}\n";
-   input << "home_hq_character_map={\n";
-   input << "max=6552\n";
-   input << "14151 = { 1 4 }\n";
    input << "}\n";
 
-   CharacterManager character_manager(input);
+    std::stringstream log;
+    std::streambuf* cout_buffer = std::cout.rdbuf();
+    std::cout.rdbuf(log.rdbuf());
 
-   EXPECT_THAT(character_manager.GetCharacters(),
-       testing::UnorderedElementsAre(testing::Pair(1, Character({.id = 1, .roles = {"general"}, .is_commander = true})),
-           testing::Pair(3, Character({.id = 3, .roles = {"general"}, .is_commander = false})),
-           testing::Pair(4, Character({.id = 4, .roles = {"admiral"}, .is_commander = true})),
-           testing::Pair(6, Character({.id = 6, .roles = {"admiral"}, .is_commander = false}))));
+    CharacterManager _(input);
+
+    std::cout.rdbuf(cout_buffer);
+
+    EXPECT_THAT(log.str(), testing::HasSubstr("[INFO] \tFound 2 dead characters. Hiding the bodies.\n"));
 }
 
 
@@ -353,29 +350,6 @@ TEST(Vic3WorldCharactersVic3CharacterManagerImporter, OriginTagsMatchesAreLogged
    std::cout.rdbuf(cout_buffer);
 
    EXPECT_THAT(log.str(), testing::HasSubstr("[INFO] \tFound home countries of 1 exiles.\n"));
-}
-
-
-TEST(Vic3WorldCharactersVic3CharacterManagerImporter, CommanderCountIsLogged)
-{
-   std::stringstream input;
-   input << "={\n";
-   input << "home_hq_character_map={\n";
-   input << "max=6552\n";
-   input << "14151 = { 1 2 3 4 5 6 7 }\n";
-   input << "25617 = { 8 9 10 }\n";
-   input << "}\n";
-   input << "}\n";
-
-   std::stringstream log;
-   std::streambuf* cout_buffer = std::cout.rdbuf();
-   std::cout.rdbuf(log.rdbuf());
-
-   CharacterManager _(input);
-
-   std::cout.rdbuf(cout_buffer);
-
-   EXPECT_THAT(log.str(), testing::HasSubstr("[INFO] \tFound 10 employed commanders.\n"));
 }
 
 }  // namespace vic3

--- a/src/vic3_world/world/vic3_world_importer_tests.cpp
+++ b/src/vic3_world/world/vic3_world_importer_tests.cpp
@@ -163,7 +163,7 @@ TEST(Vic3worldWorldVic3worldimporter, WorldCanBeImported)
                    .ig_id = 2,
                    .roles = {"general"},
                    .rank = 2,
-                   .is_commander = true,
+                   .formation_id = 1234,
                })),
            testing::Pair(4,
                Character({
@@ -187,7 +187,7 @@ TEST(Vic3worldWorldVic3worldimporter, WorldCanBeImported)
                    .ig_id = 3,
                    .roles = {"general", "politician"},
                    .rank = 1,
-                   .is_commander = true,
+                   .formation_id = 1234,
                })),
            testing::Pair(6,
                Character({


### PR DESCRIPTION
Fixed employment detection for generals & admirals in a HQ-less world.
Cleaned out dead characters who were being converted without IGs.