### PR TITLE
Map PDX's Long sentinel value to -1 for use in conversion logic.

### DIFF
--- a/src/hoi4_world/characters/hoi4_characters_converter.cpp
+++ b/src/hoi4_world/characters/hoi4_characters_converter.cpp
@@ -88,7 +88,8 @@ std::pair<int, hoi4::Character> ConvertCountryLeader(const std::map<int, vic3::I
    }
 
    int leader_id;
-   if (leader_type == "prime_minister")
+   // If head of state doesn't exist, default to prime_minister. (Happens with monarchical subjects.)
+   if (leader_type == "prime_minister" || source_country.GetHeadOfStateId() == -1)
    {
       leader_id = FindPrimeMinister(igs, source_country);
    }

--- a/src/vic3_world/countries/vic3_country.h
+++ b/src/vic3_world/countries/vic3_country.h
@@ -48,7 +48,7 @@ struct CountryOptions
    std::set<int> primary_culture_ids;
    std::set<std::string> primary_cultures;
    std::optional<date> last_election;
-   std::int64_t head_of_state_id = 0;
+   int head_of_state_id = 0;
    std::vector<int> character_ids;
    std::vector<int> ig_ids;
    std::set<int> puppets;
@@ -121,7 +121,7 @@ class Country
    [[nodiscard]] const std::set<std::string>& GetPrimaryCultures() const { return primary_cultures_; }
    [[nodiscard]] const std::set<int>& GetPrimaryCultureIds() const { return primary_culture_ids_; }
    [[nodiscard]] const std::optional<date>& GetLastElection() const { return last_election_; }
-   [[nodiscard]] std::int64_t GetHeadOfStateId() const { return head_of_state_id_; }
+   [[nodiscard]] int GetHeadOfStateId() const { return head_of_state_id_; }
    [[nodiscard]] const std::vector<int>& GetCharacterIds() const { return character_ids_; }
    [[nodiscard]] const std::vector<int>& GetInterestGroupIds() const { return ig_ids_; }
    [[nodiscard]] const std::set<int>& GetPuppets() const { return puppets_; }
@@ -171,7 +171,7 @@ class Country
    std::set<std::string> primary_cultures_;
    std::set<int> primary_culture_ids_;  // Resolve to culture name before HoI
    std::optional<date> last_election_;
-   std::int64_t head_of_state_id_ = 0;
+   int head_of_state_id_ = 0;
    std::vector<int> character_ids_;
    std::vector<int> ig_ids_;
    std::set<int> puppets_;

--- a/src/vic3_world/countries/vic3_country_importer.cpp
+++ b/src/vic3_world/countries/vic3_country_importer.cpp
@@ -100,7 +100,15 @@ vic3::CountryImporter::CountryImporter()
       }
    });
    country_parser_.registerKeyword("ruler", [this](std::istream& input_stream) {
-      options_.head_of_state_id = commonItems::getLlong(input_stream);
+      const int64_t temp_number = commonItems::getLlong(input_stream);
+      if (temp_number == 4294967295)
+      {
+         options_.head_of_state_id = -1;
+      }
+      else
+      {
+         options_.head_of_state_id = static_cast<int>(temp_number);
+      }
    });
 
    country_parser_.registerKeyword("dead", [this](std::istream& input_stream) {

--- a/src/vic3_world/countries/vic3_country_importer_tests.cpp
+++ b/src/vic3_world/countries/vic3_country_importer_tests.cpp
@@ -78,6 +78,21 @@ TEST(Vic3WorldCountriesCountryImporter, ItemsCanBeInput)
 }
 
 
+TEST(Vic3WorldCountriesCountryImporter, LongSentinelValueMapsToNegativeOne)
+{
+   std::stringstream input;
+   input << "={\n";
+   input << "\tcapital=4294967295\n";
+   input << "\truler=4294967295\n";
+   input << "}";
+   const auto country = CountryImporter{}.ImportCountry(42, input, {});
+
+   EXPECT_TRUE(country.has_value());
+   EXPECT_EQ(country.value_or(Country({})).GetCapitalState(), std::optional<int>(-1));
+   EXPECT_EQ(country.value_or(Country({})).GetHeadOfStateId(), -1);
+}
+
+
 TEST(Vic3WorldCountriesCountryImporter, Pre1_5DynamicsCanBeImported)
 {
    std::stringstream input;


### PR DESCRIPTION
Monarchial subjects should properly get their most powerful governmental IG leader as the country leader now. Instead of no one at all.