### PR TITLE
Log when province mappings are in the wrong region.

### DIFF
--- a/src/mappers/provinces/province_mapper_importer.cpp
+++ b/src/mappers/provinces/province_mapper_importer.cpp
@@ -62,13 +62,12 @@ std::map<std::string, std::string> GenerateProvinceToStateMap(
 }
 
 void AreVic3ProvincesFromSameState(const std::vector<std::string>& provinces_from_map,
-    std::map<std::string, std::string> province_to_state_map)
+    const std::map<std::string, std::string>& province_to_state_map)
 {
    std::set<std::string> state_names;
    for (const auto& province: provinces_from_map)
    {
-      auto linked_state = province_to_state_map.find(province);
-      if (linked_state != province_to_state_map.end())
+      if (auto linked_state = province_to_state_map.find(province); linked_state != province_to_state_map.end())
       {
          state_names.insert(linked_state->second);
       }
@@ -82,7 +81,26 @@ void AreVic3ProvincesFromSameState(const std::vector<std::string>& provinces_fro
              "Province {} is designated as part of {} in Vic3 data and is placed in a mapping with provinces from "
              "other states.",
              province_from_map,
-             province_to_state_map[province_from_map]);
+             province_to_state_map.at(province_from_map));
+      }
+   }
+}
+
+
+void IsMappingInWrongRegion(std::string_view current_region,
+    const std::vector<std::string>& provinces_from_map,
+    const std::map<std::string, std::string>& province_to_state_map)
+{
+   for (const auto& province: provinces_from_map)
+   {
+      auto linked_state = province_to_state_map.find(province);
+      if (linked_state != province_to_state_map.end() && linked_state->second != current_region)
+      {
+         Log(LogLevel::Warning) << fmt::format(
+             "Province {} is designated as part of {} in Vic3 data and is placed in a mapping in the {} region.",
+             province,
+             province_to_state_map.at(province),
+             current_region);
       }
    }
 }
@@ -92,7 +110,7 @@ void CheckAllHoi4ProvincesMapped(const mappers::Hoi4ToVic3ProvinceMapping& hoi4_
     const commonItems::ModFilesystem& filesystem)
 {
    const auto definition_location = filesystem.GetActualFileLocation("/map/definition.csv");
-   if (!definition_location.has_value())
+   if (!definition_location.has_value()) 
    {
       throw std::runtime_error("Could not find /map/definition.csv");
    }
@@ -136,6 +154,10 @@ mappers::ProvinceMapperImporter::ProvinceMapperImporter(const commonItems::ModFi
 
    mapping_parser_.registerKeyword("link", [this, vic3_state_regions](std::istream& input_stream) {
       const auto the_mapping = mapping_importer_.ImportProvinceMapping(input_stream);
+      if (the_mapping.comment.has_value())
+      {
+         current_region_ = the_mapping.comment.value();
+      }
       if (the_mapping.vic3_provinces.empty() && the_mapping.hoi4_provinces.empty())
       {
          return;
@@ -143,10 +165,17 @@ mappers::ProvinceMapperImporter::ProvinceMapperImporter(const commonItems::ModFi
 
       if (!vic3_state_regions.empty())
       {
-         auto vic3_province = the_mapping.vic3_provinces;
-         AreVic3ProvincesFromSameState(vic3_province, province_to_state_map_);
+         AreVic3ProvincesFromSameState(the_mapping.vic3_provinces, province_to_state_map_);
       }
 
+      if (!vic3_state_regions.empty())
+      {
+         AreVic3ProvincesFromSameState(the_mapping.vic3_provinces, province_to_state_map_);
+      }
+      if (!vic3_state_regions.empty())
+      {
+         IsMappingInWrongRegion(current_region_, the_mapping.vic3_provinces, province_to_state_map_);
+      }
 
       for (auto color: the_mapping.vic3_provinces)
       {
@@ -171,6 +200,7 @@ mappers::ProvinceMapperImporter::ProvinceMapperImporter(const commonItems::ModFi
 
 mappers::ProvinceMapper mappers::ProvinceMapperImporter::ImportProvinceMappings()
 {
+   Log(LogLevel::Info) << "Importing province mappings.";
    vic3_to_hoi4_province_map_.clear();
    hoi4_to_vic3_province_map_.clear();
 

--- a/src/mappers/provinces/province_mapper_importer.cpp
+++ b/src/mappers/provinces/province_mapper_importer.cpp
@@ -110,7 +110,7 @@ void CheckAllHoi4ProvincesMapped(const mappers::Hoi4ToVic3ProvinceMapping& hoi4_
     const commonItems::ModFilesystem& filesystem)
 {
    const auto definition_location = filesystem.GetActualFileLocation("/map/definition.csv");
-   if (!definition_location.has_value()) 
+   if (!definition_location.has_value())
    {
       throw std::runtime_error("Could not find /map/definition.csv");
    }

--- a/src/mappers/provinces/province_mapper_importer.cpp
+++ b/src/mappers/provinces/province_mapper_importer.cpp
@@ -77,7 +77,7 @@ void AreVic3ProvincesFromSameState(const std::vector<std::string>& provinces_fro
    {
       for (const auto& province_from_map: provinces_from_map)
       {
-         Log(LogLevel::Warning) << fmt::format(
+         Log(LogLevel::Debug) << fmt::format(
              "Province {} is designated as part of {} in Vic3 data and is placed in a mapping with provinces from "
              "other states.",
              province_from_map,
@@ -96,7 +96,7 @@ void IsMappingInWrongRegion(std::string_view current_region,
       auto linked_state = province_to_state_map.find(province);
       if (linked_state != province_to_state_map.end() && linked_state->second != current_region)
       {
-         Log(LogLevel::Warning) << fmt::format(
+         Log(LogLevel::Debug) << fmt::format(
              "Province {} is designated as part of {} in Vic3 data and is placed in a mapping in the {} region.",
              province,
              province_to_state_map.at(province),
@@ -166,14 +166,6 @@ mappers::ProvinceMapperImporter::ProvinceMapperImporter(const commonItems::ModFi
       if (!vic3_state_regions.empty())
       {
          AreVic3ProvincesFromSameState(the_mapping.vic3_provinces, province_to_state_map_);
-      }
-
-      if (!vic3_state_regions.empty())
-      {
-         AreVic3ProvincesFromSameState(the_mapping.vic3_provinces, province_to_state_map_);
-      }
-      if (!vic3_state_regions.empty())
-      {
          IsMappingInWrongRegion(current_region_, the_mapping.vic3_provinces, province_to_state_map_);
       }
 

--- a/src/mappers/provinces/province_mapper_importer.h
+++ b/src/mappers/provinces/province_mapper_importer.h
@@ -33,6 +33,8 @@ class ProvinceMapperImporter
    commonItems::parser mapping_parser_;
    ProvinceMappingImporter mapping_importer_;
 
+   std::string current_region_;
+
    Vic3ToHoi4ProvinceMapping vic3_to_hoi4_province_map_;
    Hoi4ToVic3ProvinceMapping hoi4_to_vic3_province_map_;
    std::map<std::string, std::string> province_to_state_map_;

--- a/src/mappers/provinces/province_mapping.h
+++ b/src/mappers/provinces/province_mapping.h
@@ -3,6 +3,8 @@
 
 
 
+#include <optional>
+#include <string>
 #include <vector>
 
 
@@ -14,6 +16,7 @@ struct ProvinceMapping
 {
    std::vector<std::string> vic3_provinces;
    std::vector<int> hoi4_provinces;
+   std::optional<std::string> comment;
 };
 
 }  // namespace mappers

--- a/src/mappers/provinces/province_mapping_importer.cpp
+++ b/src/mappers/provinces/province_mapping_importer.cpp
@@ -18,7 +18,17 @@ mappers::ProvinceMappingImporter::ProvinceMappingImporter()
    parser_.registerKeyword("hoi4", [this](std::istream& theStream) {
       hoi4_provinces_.push_back(commonItems::getInt(theStream));
    });
-   parser_.registerKeyword("comment", commonItems::ignoreItem);
+   parser_.registerKeyword("comment", [this](std::istream& the_stream) {
+      const std::string raw_string = commonItems::getString(the_stream);
+      if (const size_t start = raw_string.find_first_not_of("* "); start != std::string::npos)
+      {
+          comment_ = raw_string.substr(start, raw_string.length());
+          if (const size_t last = comment_.value().find_last_not_of("* "); last != std::string::npos)
+          {
+              comment_ = comment_.value().substr(0, last + 1);
+          }
+      }
+   });
    parser_.IgnoreAndLogUnregisteredItems();
 }
 
@@ -27,8 +37,9 @@ mappers::ProvinceMapping mappers::ProvinceMappingImporter::ImportProvinceMapping
 {
    vic3_provinces_.clear();
    hoi4_provinces_.clear();
+   comment_.reset();
 
    parser_.parseStream(input_stream);
 
-   return ProvinceMapping{vic3_provinces_, hoi4_provinces_};
+   return ProvinceMapping{.vic3_provinces = vic3_provinces_, .hoi4_provinces = hoi4_provinces_, .comment = comment_};
 }

--- a/src/mappers/provinces/province_mapping_importer.cpp
+++ b/src/mappers/provinces/province_mapping_importer.cpp
@@ -22,11 +22,11 @@ mappers::ProvinceMappingImporter::ProvinceMappingImporter()
       const std::string raw_string = commonItems::getString(the_stream);
       if (const size_t start = raw_string.find_first_not_of("* "); start != std::string::npos)
       {
-          comment_ = raw_string.substr(start, raw_string.length());
-          if (const size_t last = comment_.value().find_last_not_of("* "); last != std::string::npos)
-          {
-              comment_ = comment_.value().substr(0, last + 1);
-          }
+         comment_ = raw_string.substr(start, raw_string.length());
+         if (const size_t last = comment_.value().find_last_not_of("* "); last != std::string::npos)
+         {
+            comment_ = comment_.value().substr(0, last + 1);
+         }
       }
    });
    parser_.IgnoreAndLogUnregisteredItems();

--- a/src/mappers/provinces/province_mapping_importer.h
+++ b/src/mappers/provinces/province_mapping_importer.h
@@ -3,7 +3,9 @@
 
 
 
-#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "external/commonItems/Parser.h"
 #include "src/mappers/provinces/province_mapping.h"
@@ -24,6 +26,7 @@ class ProvinceMappingImporter
 
    std::vector<std::string> vic3_provinces_;
    std::vector<int> hoi4_provinces_;
+   std::optional<std::string> comment_;
 };
 
 }  // namespace mappers

--- a/src/mappers/provinces/province_mapping_importer_tests.cpp
+++ b/src/mappers/provinces/province_mapping_importer_tests.cpp
@@ -51,4 +51,25 @@ TEST(MappersProvincesProvinceMappingImporterTests, HoI4ProvincesCanBeAdded)
    EXPECT_THAT(mapping.hoi4_provinces, testing::ElementsAre(42, 144));
 }
 
+
+TEST(MappersProvincesProvinceMappingImporterTests, CommentDefaultsToNullopt)
+{
+   std::stringstream input;
+
+   const auto mapping = ProvinceMappingImporter{}.ImportProvinceMapping(input);
+
+   EXPECT_FALSE(mapping.comment.has_value());
+}
+
+
+TEST(MappersProvincesProvinceMappingImporterTests, CommentCanBeSet)
+{
+   std::stringstream input;
+   input << R"(= { comment = "test_comment" })";
+
+   const auto mapping = ProvinceMappingImporter{}.ImportProvinceMapping(input);
+
+   EXPECT_EQ(mapping.comment.value_or(""), "test_comment");
+}
+
 }  // namespace mappers


### PR DESCRIPTION
This ensures the province mappings file matches Vic3's region definitions.